### PR TITLE
Make density difference opt default false for the moment.

### DIFF
--- a/ipie/estimators/generic.py
+++ b/ipie/estimators/generic.py
@@ -122,9 +122,7 @@ def local_energy_cholesky_opt_dG(system, ecore, Ghalfa, Ghalfb, trial):
     e1 = de1 - ecore + trial.e1b
     e2 = de2 + dde2 - trial.e2b
 
-    etot = e1+e2
-
-    etot0, e10, e20  = local_energy_cholesky_opt(system,ecore,Ghalfa,Ghalfb, trial)
+    etot = e1 + e2
 
     return (etot, e1, e2)
 

--- a/ipie/hamiltonians/generic.py
+++ b/ipie/hamiltonians/generic.py
@@ -71,7 +71,7 @@ class Generic(object):
         self.verbose = verbose
         self.exact_eri = options.get("exact_eri", False)
         self.mixed_precision = options.get("mixed_precision", False)
-        self.density_diff = options.get("density_diff", True)
+        self.density_diff = options.get("density_diff", False)
 
         if self.mixed_precision:
             if not self.density_diff:


### PR DESCRIPTION
Density difference trick was defaulting to true and accidentally computing local energy twice.