### PR TITLE
Add factory method from hdf5

### DIFF
--- a/ipie/hamiltonians/utils.py
+++ b/ipie/hamiltonians/utils.py
@@ -16,7 +16,6 @@
 #          Joonho Lee
 #
 
-import sys
 import time
 
 import numpy

--- a/ipie/legacy/qmc/tests/test_afqmc.py
+++ b/ipie/legacy/qmc/tests/test_afqmc.py
@@ -38,18 +38,9 @@ def test_constructor():
                 "stabilise_freq": 10,
             },
             "walkers": {"pop_control": "comb"},
-            "estimates": {
-                "filename": tmpf.name,
-                "mixed": {"energy_eval_freq": 1},
-            },
+            "estimates": {"filename": tmpf.name, "mixed": {"energy_eval_freq": 1}},
         }
-        model = {
-            "name": "UEG",
-            "rs": 2.44,
-            "ecut": 4,
-            "nup": 7,
-            "ndown": 7,
-        }
+        model = {"name": "UEG", "rs": 2.44, "ecut": 4, "nup": 7, "ndown": 7}
         from ipie.legacy.systems.ueg import UEG
 
         system = UEG(model)
@@ -78,21 +69,10 @@ def test_ueg():
                 "pop_control_freq": 1,
                 "stabilise_freq": 10,
             },
-            "system": {
-                "name": "UEG",
-                "rs": 2.44,
-                "ecut": 2,
-                "nup": 7,
-                "ndown": 7,
-            },
-            "hamiltonian": {
-                "name": "UEG",
-            },
+            "system": {"name": "UEG", "rs": 2.44, "ecut": 2, "nup": 7, "ndown": 7},
+            "hamiltonian": {"name": "UEG"},
             "walkers": {"pop_control": "comb"},
-            "estimates": {
-                "filename": tmpf.name,
-                "mixed": {"energy_eval_freq": 1},
-            },
+            "estimates": {"filename": tmpf.name, "mixed": {"energy_eval_freq": 1}},
             "trial": {"name": "hartree_fock"},
         }
         comm = MPI.COMM_WORLD
@@ -136,23 +116,11 @@ def test_hubbard():
                 "pop_control_freq": 1,
                 "stabilise_freq": 10,
             },
-            "system": {
-                "name": "Generic",
-                "nup": 7,
-                "ndown": 7,
-            },
+            "system": {"name": "Generic", "nup": 7, "ndown": 7},
             "walkers": {"pop_control": "comb"},
-            "hamiltonian": {
-                "name": "Hubbard",
-                "nx": 4,
-                "ny": 4,
-                "U": 4,
-            },
+            "hamiltonian": {"name": "Hubbard", "nx": 4, "ny": 4, "U": 4},
             "trial": {"name": "hubbard_uhf"},
-            "estimates": {
-                "filename": tmpf.name,
-                "mixed": {"energy_eval_freq": 1},
-            },
+            "estimates": {"filename": tmpf.name, "mixed": {"energy_eval_freq": 1}},
             "propagator": {"hubbard_stratonovich": "discrete"},
         }
         comm = MPI.COMM_WORLD
@@ -187,23 +155,11 @@ def test_hubbard_complex():
                 "pop_control_freq": 1,
                 "stabilise_freq": 10,
             },
-            "system": {
-                "name": "Generic",
-                "nup": 7,
-                "ndown": 7,
-            },
+            "system": {"name": "Generic", "nup": 7, "ndown": 7},
             "walkers": {"pop_control": "comb"},
-            "hamiltonian": {
-                "name": "Hubbard",
-                "nx": 4,
-                "ny": 4,
-                "U": 4,
-            },
+            "hamiltonian": {"name": "Hubbard", "nx": 4, "ny": 4, "U": 4},
             "trial": {"name": "hubbard_UHF"},
-            "estimates": {
-                "filename": tmpf.name,
-                "mixed": {"energy_eval_freq": 1},
-            },
+            "estimates": {"filename": tmpf.name, "mixed": {"energy_eval_freq": 1}},
             "propagator": {"hubbard_stratonovich": "continuous"},
         }
         comm = MPI.COMM_WORLD
@@ -240,19 +196,14 @@ def test_generic():
                 "stabilise_freq": 10,
             },
             "walkers": {"pop_control": "comb"},
-            "estimates": {
-                "filename": tmpf.name,
-                "mixed": {"energy_eval_freq": 1},
-            },
+            "estimates": {"filename": tmpf.name, "mixed": {"energy_eval_freq": 1}},
             "trial": {"name": "MultiSlater"},
         }
         numpy.random.seed(7)
         h1e, chol, enuc, eri = generate_hamiltonian(nmo, nelec, cplx=False)
         sys = Generic(nelec=nelec)
         ham = HamGeneric(
-            h1e=numpy.array([h1e, h1e]),
-            chol=chol.reshape((-1, nmo * nmo)).T.copy(),
-            ecore=enuc,
+            h1e=numpy.array([h1e, h1e]), chol=chol.reshape((-1, nmo * nmo)).T.copy(), ecore=enuc
         )
         comm = MPI.COMM_WORLD
         afqmc = AFQMC(comm=comm, system=sys, hamiltonian=ham, options=options)
@@ -299,9 +250,7 @@ def test_generic_single_det():
         sys_opts = {"sparse": True}
         sys = Generic(nelec=nelec)
         ham = HamGeneric(
-            h1e=numpy.array([h1e, h1e]),
-            chol=chol.reshape((-1, nmo * nmo)).T.copy(),
-            ecore=enuc,
+            h1e=numpy.array([h1e, h1e]), chol=chol.reshape((-1, nmo * nmo)).T.copy(), ecore=enuc
         )
         comm = MPI.COMM_WORLD
         afqmc = AFQMC(comm=comm, system=sys, hamiltonian=ham, options=options)

--- a/ipie/legacy/trial_wavefunction/coherent_state.py
+++ b/ipie/legacy/trial_wavefunction/coherent_state.py
@@ -1054,11 +1054,7 @@ class CoherentState(object):
                 # single coherent state energy
                 phi = HarmonicOscillator(system.m, system.w0, order=0, shift=self.shift)
                 Lap = phi.laplacian(self.shift)
-                (
-                    energy_single,
-                    e1b_single,
-                    e2b_single,
-                ) = local_energy_hubbard_holstein_jax(
+                (energy_single, e1b_single, e2b_single,) = local_energy_hubbard_holstein_jax(
                     system.T,
                     system.U,
                     system.g,

--- a/ipie/legacy/trial_wavefunction/utils.py
+++ b/ipie/legacy/trial_wavefunction/utils.py
@@ -44,7 +44,7 @@ def get_trial_wavefunction(
         if wfn_file is not None:
             if verbose:
                 print(f"# Reading wavefunction from {wfn_file}.")
-            read, psi0 = read_qmcpack_wfn_hdf(wfn_file)
+            read, psi0, _ = read_qmcpack_wfn_hdf(wfn_file)
             thresh = options.get("threshold", None)
             if thresh is not None:
                 coeff = read[0]
@@ -68,8 +68,7 @@ def get_trial_wavefunction(
             na = system.nup
             nb = system.ndown
             wfn = numpy.zeros(
-                (1, hamiltonian.nbasis, system.nup + system.ndown),
-                dtype=numpy.complex128,
+                (1, hamiltonian.nbasis, system.nup + system.ndown), dtype=numpy.complex128
             )
             coeffs = numpy.array([1.0 + 0j])
             I = numpy.identity(hamiltonian.nbasis, dtype=numpy.complex128)

--- a/ipie/qmc/afqmc.py
+++ b/ipie/qmc/afqmc.py
@@ -292,6 +292,7 @@ class AFQMC(object):
                 sha1, branch, local_mods, this_uuid, self.mpi_handler.size
             )
             mem_avail = get_host_memory()
+            print(f"# MPI communicator : {type(self.mpi_handler.comm)}")
             print(f"# Available memory on the node is {mem_avail:4.3f} GB")
 
     def setup_estimators(

--- a/ipie/qmc/afqmc.py
+++ b/ipie/qmc/afqmc.py
@@ -25,10 +25,12 @@ from typing import Dict, Optional, Tuple
 from ipie.config import config
 from ipie.estimators.estimator_base import EstimatorBase
 from ipie.estimators.handler import EstimatorHandler
+from ipie.hamiltonians.utils import get_hamiltonian
 from ipie.propagation.propagator import Propagator
 from ipie.qmc.options import QMCParams
 from ipie.qmc.utils import set_rng_seed
 from ipie.systems.generic import Generic
+from ipie.trial_wavefunction.utils import get_trial_wavefunction
 from ipie.utils.backend import arraylib as xp
 from ipie.utils.backend import get_host_memory, synchronize
 from ipie.utils.io import to_json
@@ -67,14 +69,7 @@ class AFQMC(object):
     """
 
     def __init__(
-        self,
-        system,
-        hamiltonian,
-        trial,
-        walkers,
-        propagator,
-        params: QMCParams,
-        verbose: int = 0,
+        self, system, hamiltonian, trial, walkers, propagator, params: QMCParams, verbose: int = 0
     ):
         self.system = system
         self.hamiltonian = hamiltonian
@@ -103,6 +98,7 @@ class AFQMC(object):
         stabilize_freq=5,
         pop_control_freq=5,
         verbose=True,
+        mpi_handler=None,
     ) -> "AFQMC":
         """Factory method to build AFQMC driver from hamiltonian and trial wavefunction.
 
@@ -134,8 +130,11 @@ class AFQMC(object):
         verbose : bool
             Log verbosity. Default True i.e. print information to stdout.
         """
-        mpi_handler = MPIHandler()
-        comm = mpi_handler.comm
+        if mpi_handler is None:
+            mpi_handler = MPIHandler()
+            comm = mpi_handler.comm
+        else:
+            comm = mpi_handler.comm
         params = QMCParams(
             num_walkers=num_walkers,
             total_num_walkers=num_walkers * comm.size,
@@ -179,6 +178,80 @@ class AFQMC(object):
             verbose=(verbose and comm.rank == 0),
         )
 
+    @staticmethod
+    # TODO: wavefunction type, trial type, hamiltonian type
+    def build_from_hdf5(
+        ham_file,
+        wfn_file,
+        num_walkers: int = 100,
+        seed: int = None,
+        num_steps_per_block: int = 25,
+        num_blocks: int = 100,
+        timestep: float = 0.005,
+        stabilize_freq=5,
+        pop_control_freq=5,
+        num_dets_chunk=1,
+        pack_cholesky=True,
+        verbose=True,
+    ) -> "AFQMC":
+        """Factory method to build AFQMC driver from hamiltonian and trial wavefunction.
+
+        Parameters
+        ----------
+        num_elec: tuple(int, int)
+            Number of alpha and beta electrons.
+        ham_file : str
+            Path to Hamiltonian describing the system.
+        wfn_file : str
+            Path to Trial wavefunction
+        num_walkers : int
+            Number of walkers per MPI process used in the simulation. The TOTAL
+                number of walkers is num_walkers * number of processes.
+        num_steps_per_block : int
+            Number of Monte Carlo steps before estimators are evaluatied.
+                Default 25.
+        num_blocks : int
+            Number of blocks to perform. Total number of steps = num_blocks *
+                num_steps_per_block.
+        timestep : float
+            Imaginary timestep. Default 0.005.
+        stabilize_freq : float
+            Frequency at which to perform QR factorization of walkers (in units
+                of steps.) Default 25.
+        pop_control_freq : int
+            Frequency at which to perform population control (in units of
+                steps.) Default 25.
+        num_det_chunks : int
+            Size of chunks of determinants to process during batching. Default=1 (no batching).
+        pack_cholesky : bool
+            Use symmetry to reduce memory consumption of integrals. Default True.
+        verbose : bool
+            Log verbosity. Default True i.e. print information to stdout.
+        """
+        mpi_handler = MPIHandler()
+        _verbose = verbose and mpi_handler.comm.rank == 0
+        ham = get_hamiltonian(
+            ham_file, mpi_handler.scomm, verbose=_verbose, pack_chol=pack_cholesky
+        )
+        trial = get_trial_wavefunction(
+            ham.nbasis, wfn_file, ndet_chunks=num_dets_chunk, verbose=_verbose
+        )
+        trial.half_rotate(ham, mpi_handler.scomm)
+        return AFQMC.build(
+            trial.nelec,
+            ham,
+            trial,
+            num_walkers=num_walkers,
+            seed=seed,
+            num_steps_per_block=num_steps_per_block,
+            num_blocks=num_blocks,
+            timestep=timestep,
+            stabilize_freq=stabilize_freq,
+            pop_control_freq=pop_control_freq,
+            verbose=verbose,
+            mpi_handler=mpi_handler,
+        )
+
     def distribute_hamiltonian(self):
         if self.mpi_handler.nmembers > 1:
             if self.mpi_handler.comm.rank == 0:
@@ -216,19 +289,13 @@ class AFQMC(object):
             local_mods = []
         if self.verbose:
             self.sys_info = print_env_info(
-                sha1,
-                branch,
-                local_mods,
-                this_uuid,
-                self.mpi_handler.size,
+                sha1, branch, local_mods, this_uuid, self.mpi_handler.size
             )
             mem_avail = get_host_memory()
             print(f"# Available memory on the node is {mem_avail:4.3f} GB")
 
     def setup_estimators(
-        self,
-        filename,
-        additional_estimators: Optional[Dict[str, EstimatorBase]] = None,
+        self, filename, additional_estimators: Optional[Dict[str, EstimatorBase]] = None
     ):
         self.accumulators = WalkerAccumulator(
             ["Weight", "WeightFactor", "HybridEnergy"], self.params.num_steps_per_block
@@ -254,11 +321,7 @@ class AFQMC(object):
         self.estimators.initialize(comm)
         # Calculate estimates for initial distribution of walkers.
         self.estimators.compute_estimators(
-            comm,
-            self.system,
-            self.hamiltonian,
-            self.trial,
-            self.walkers,
+            comm, self.system, self.hamiltonian, self.trial, self.walkers
         )
         self.accumulators.update(self.walkers)
         self.estimators.print_block(comm, 0, self.accumulators)
@@ -344,12 +407,7 @@ class AFQMC(object):
                 self.tortho += time.time() - start
             start = time.time()
 
-            self.propagator.propagate_walkers(
-                self.walkers,
-                self.hamiltonian,
-                self.trial,
-                eshift,
-            )
+            self.propagator.propagate_walkers(self.walkers, self.hamiltonian, self.trial, eshift)
 
             self.tprop_fbias = self.propagator.timer.tfbias
             self.tprop_ovlp = self.propagator.timer.tovlp
@@ -362,10 +420,7 @@ class AFQMC(object):
             if step > 1:
                 wbound = self.pcontrol.total_weight * 0.10
                 xp.clip(
-                    self.walkers.weight,
-                    a_min=-wbound,
-                    a_max=wbound,
-                    out=self.walkers.weight,
+                    self.walkers.weight, a_min=-wbound, a_max=wbound, out=self.walkers.weight
                 )  # in-place clipping
 
             synchronize()
@@ -396,11 +451,7 @@ class AFQMC(object):
             start = time.time()
             if step % self.params.num_steps_per_block == 0:
                 self.estimators.compute_estimators(
-                    comm,
-                    self.system,
-                    self.hamiltonian,
-                    self.trial,
-                    self.walkers,
+                    comm, self.system, self.hamiltonian, self.trial, self.walkers
                 )
                 self.estimators.print_block(
                     comm, step // self.params.num_steps_per_block, self.accumulators
@@ -470,9 +521,7 @@ class AFQMC(object):
                 )
                 print(
                     "#     -   Weights Update: {:.6f} s / call for {} call(s) in each of {} blocks".format(
-                        (self.tprop_update + self.tprop_clip) / (nblocks * nsteps),
-                        nsteps,
-                        nblocks,
+                        (self.tprop_update + self.tprop_clip) / (nblocks * nsteps), nsteps, nblocks
                     )
                 )
                 print(

--- a/ipie/qmc/calc.py
+++ b/ipie/qmc/calc.py
@@ -84,11 +84,11 @@ def get_driver(options: dict, comm: MPI.COMM_WORLD) -> AFQMC:
         system = get_system(
             sys_opts, verbose=verbosity, comm=comm
         )  # Have to deal with shared comm in the future. I think we will remove this...
-        ham_file = get_input_value(ham_opts, 'integrals', None, verbose=verbosity)
+        ham_file = get_input_value(ham_opts, "integrals", None, verbose=verbosity)
         if ham_file is None:
             raise ValueError("Hamiltonian filename not specified.")
         pack_chol = get_input_value(
-            ham_opts, 'symmetry', True, alias=['pack_chol', 'pack_cholesky'], verbose=verbosity
+            ham_opts, "symmetry", True, alias=["pack_chol", "pack_cholesky"], verbose=verbosity
         )
         hamiltonian = get_hamiltonian(
             ham_file, mpi_handler.scomm, pack_chol=pack_chol, verbose=verbosity

--- a/ipie/qmc/calc.py
+++ b/ipie/qmc/calc.py
@@ -50,11 +50,7 @@ def get_driver(options: dict, comm: MPI.COMM_WORLD) -> AFQMC:
     verbosity = options.get("verbosity", 1)
     qmc_opts = get_input_value(options, "qmc", default={}, alias=["qmc_options"])
     sys_opts = get_input_value(
-        options,
-        "system",
-        default={},
-        alias=["model"],
-        verbose=verbosity > 1,
+        options, "system", default={}, alias=["model"], verbose=verbosity > 1
     )
     ham_opts = get_input_value(options, "hamiltonian", default={}, verbose=verbosity > 1)
     # backward compatibility with previous code (to be removed)
@@ -64,19 +60,11 @@ def get_driver(options: dict, comm: MPI.COMM_WORLD) -> AFQMC:
         ham_opts[item[0]] = item[1]
 
     twf_opt = get_input_value(
-        options,
-        "trial",
-        default={},
-        alias=["trial_wavefunction"],
-        verbose=verbosity > 1,
+        options, "trial", default={}, alias=["trial_wavefunction"], verbose=verbosity > 1
     )
 
     wlk_opts = get_input_value(
-        options,
-        "walkers",
-        default={},
-        alias=["walker", "walker_opts"],
-        verbose=verbosity > 1,
+        options, "walkers", default={}, alias=["walker", "walker_opts"], verbose=verbosity > 1
     )
     wlk_opts["pop_control"] = wlk_opts.get("pop_control", "pair_branch")
     wlk_opts["population_control"] = wlk_opts["pop_control"]
@@ -96,14 +84,19 @@ def get_driver(options: dict, comm: MPI.COMM_WORLD) -> AFQMC:
         system = get_system(
             sys_opts, verbose=verbosity, comm=comm
         )  # Have to deal with shared comm in the future. I think we will remove this...
-        hamiltonian = get_hamiltonian(system, ham_opts, verbose=verbosity, comm=comm)
+        ham_file = get_input_value(ham_opts, 'integrals', None, verbose=verbosity)
+        if ham_file is None:
+            raise ValueError("Hamiltonian filename not specified.")
+        pack_chol = get_input_value(
+            ham_opts, 'symmetry', True, alias=['pack_chol', 'pack_cholesky'], verbose=verbosity
+        )
+        hamiltonian = get_hamiltonian(
+            ham_file, mpi_handler.scomm, pack_chol=pack_chol, verbose=verbosity
+        )
         wfn_file = get_input_value(twf_opt, "filename", default="", alias=["wfn_file"])
         trial = get_trial_wavefunction(
-            system,
-            hamiltonian,
+            hamiltonian.nbasis,
             wfn_file,
-            comm=comm,
-            scomm=comm,
             verbose=verbosity,
             ndets=get_input_value(twf_opt, "ndets", default=1, alias=["num_dets"]),
             ndets_props=get_input_value(
@@ -113,6 +106,12 @@ def get_driver(options: dict, comm: MPI.COMM_WORLD) -> AFQMC:
                 twf_opt, "ndet_chunks", default=1, alias=["num_det_chunks"]
             ),
         )
+        trial.half_rotate(hamiltonian, mpi_handler.scomm)
+        if trial.compute_trial_energy:
+            trial.calculate_energy(system, hamiltonian)
+            trial.e1b = comm.bcast(trial.e1b, root=0)
+            trial.e2b = comm.bcast(trial.e2b, root=0)
+        comm.barrier()
         _, initial_walker = get_initial_walker(trial)
         walkers = UHFWalkersTrial(
             trial,
@@ -162,10 +161,7 @@ def build_afqmc_driver(
     if comm.rank != 0:
         verbosity = 0
     options = {
-        "system": {
-            "nup": nelec[0],
-            "ndown": nelec[1],
-        },
+        "system": {"nup": nelec[0], "ndown": nelec[1]},
         "qmc": {"nwalkers": num_walkers_per_task, "rng_seed": seed},
         "hamiltonian": {"integrals": hamiltonian_file},
         "trial": {"filename": wavefunction_file},

--- a/ipie/qmc/tests/test_afqmc_multi_det_batch.py
+++ b/ipie/qmc/tests/test_afqmc_multi_det_batch.py
@@ -26,7 +26,7 @@ from ipie.config import MPI
 from ipie.qmc.calc import AFQMC
 from ipie.utils.io import write_hamiltonian, write_wavefunction
 from ipie.utils.legacy_testing import build_legacy_driver_instance
-from ipie.utils.testing import build_driver_test_instance
+from ipie.utils.testing import build_driver_test_instance, get_random_phmsd_opt
 
 
 @pytest.mark.driver
@@ -226,10 +226,7 @@ def test_factory_method_particle_hole():
         nalpha = nelec[0]
         nbeta = nelec[1]
         ndet = 10
-        occa = numpy.random.randint((ndet, nalpha))
-        occb = numpy.random.randint((ndet, nbeta))
-        ci_coeffs = numpy.random.random((ndet))
-        wfn = (ci_coeffs, occa, occb)
+        wfn, _ = get_random_phmsd_opt(nalpha, nbeta, nmo, ndet=ndet)
         write_wavefunction(wfn, filename=wfnf.name)
         AFQMC.build_from_hdf5(hamilf.name, wfnf.name)
 

--- a/ipie/qmc/tests/test_afqmc_multi_det_batch.py
+++ b/ipie/qmc/tests/test_afqmc_multi_det_batch.py
@@ -23,6 +23,8 @@ import pytest
 
 from ipie.analysis.extraction import extract_mixed_estimates, extract_observable
 from ipie.config import MPI
+from ipie.qmc.calc import AFQMC
+from ipie.utils.io import write_hamiltonian, write_wavefunction
 from ipie.utils.legacy_testing import build_legacy_driver_instance
 from ipie.utils.testing import build_driver_test_instance
 
@@ -56,12 +58,7 @@ def test_generic_multi_det_batch():
             "verbosity": 0,
             "get_sha1": False,
             "qmc": options,
-            "estimates": {
-                "filename": tmpf.name,
-                "observables": {
-                    "energy": {},
-                },
-            },
+            "estimates": {"filename": tmpf.name, "observables": {"energy": {}}},
             "walkers": {"population_control": "pair_branch"},
         }
 
@@ -78,11 +75,7 @@ def test_generic_multi_det_batch():
         afqmc.run(verbose=0, estimator_filename=tmpf.name)
         afqmc.finalise(verbose=0)
         afqmc.estimators.compute_estimators(
-            comm,
-            afqmc.system,
-            afqmc.hamiltonian,
-            afqmc.trial,
-            afqmc.walkers,
+            comm, afqmc.system, afqmc.hamiltonian, afqmc.trial, afqmc.walkers
         )
         numer_batch = afqmc.estimators["energy"]["ENumer"]
         denom_batch = afqmc.estimators["energy"]["EDenom"]
@@ -96,12 +89,7 @@ def test_generic_multi_det_batch():
         }
         driver_options["qmc"]["batched"] = False
         legacy_afqmc = build_legacy_driver_instance(
-            nelec,
-            nmo,
-            trial_type="phmsd",
-            options=driver_options,
-            seed=7,
-            num_dets=ndets,
+            nelec, nmo, trial_type="phmsd", options=driver_options, seed=7, num_dets=ndets
         )
         legacy_afqmc.estimators.estimators["mixed"].print_header()
         legacy_afqmc.run(comm=comm, verbose=1)
@@ -184,12 +172,7 @@ def test_generic_multi_det_batch_noci():
             "verbosity": 0,
             "get_sha1": False,
             "qmc": options,
-            "estimates": {
-                "filename": tmpf.name,
-                "observables": {
-                    "energy": {},
-                },
-            },
+            "estimates": {"filename": tmpf.name, "observables": {"energy": {}}},
             "walkers": {"population_control": "pair_branch"},
         }
 
@@ -205,6 +188,50 @@ def test_generic_multi_det_batch_noci():
         )
         afqmc.run(verbose=0, estimator_filename=tmpf.name)
         afqmc.finalise(verbose=0)
+
+
+@pytest.mark.driver
+def test_factory_method_noci():
+    with tempfile.NamedTemporaryFile() as hamilf, tempfile.NamedTemporaryFile() as wfnf:
+        numpy.random.seed(7)
+        nmo = 17
+        nelec = (7, 3)
+        nmo = 10
+        naux = 100
+        hcore = numpy.random.random((nmo, nmo))
+        LXmn = numpy.random.random((naux, nmo, nmo))
+        write_hamiltonian(hcore, LXmn, 0.0, filename=hamilf.name)
+        nalpha = nelec[0]
+        nbeta = nelec[1]
+        ndet = 10
+        wfna = numpy.random.random((ndet, nmo, nalpha))
+        wfnb = numpy.random.random((ndet, nmo, nbeta))
+        ci_coeffs = numpy.random.random((ndet))
+        wfn = (ci_coeffs, [wfna, wfnb])
+        write_wavefunction(wfn, filename=wfnf.name)
+        AFQMC.build_from_hdf5(hamilf.name, wfnf.name)
+
+
+@pytest.mark.driver
+def test_factory_method_particle_hole():
+    with tempfile.NamedTemporaryFile() as hamilf, tempfile.NamedTemporaryFile() as wfnf:
+        numpy.random.seed(7)
+        nmo = 17
+        nelec = (7, 3)
+        nmo = 10
+        naux = 100
+        hcore = numpy.random.random((nmo, nmo))
+        LXmn = numpy.random.random((naux, nmo, nmo))
+        write_hamiltonian(hcore, LXmn, 0.0, filename=hamilf.name)
+        nalpha = nelec[0]
+        nbeta = nelec[1]
+        ndet = 10
+        occa = numpy.random.randint((ndet, nalpha))
+        occb = numpy.random.randint((ndet, nbeta))
+        ci_coeffs = numpy.random.random((ndet))
+        wfn = (ci_coeffs, occa, occb)
+        write_wavefunction(wfn, filename=wfnf.name)
+        AFQMC.build_from_hdf5(hamilf.name, wfnf.name)
 
 
 if __name__ == "__main__":

--- a/ipie/qmc/tests/test_afqmc_single_det_batch.py
+++ b/ipie/qmc/tests/test_afqmc_single_det_batch.py
@@ -24,6 +24,8 @@ import pytest
 
 from ipie.analysis.extraction import extract_mixed_estimates, extract_observable
 from ipie.config import MPI
+from ipie.qmc.calc import AFQMC
+from ipie.utils.io import write_hamiltonian, write_wavefunction
 from ipie.utils.legacy_testing import build_legacy_driver_instance
 from ipie.utils.testing import build_driver_test_instance
 
@@ -66,12 +68,7 @@ def test_generic_single_det_batch():
             "verbosity": 0,
             "get_sha1": False,
             "qmc": options,
-            "estimates": {
-                "filename": tmpf.name,
-                "observables": {
-                    "energy": {},
-                },
-            },
+            "estimates": {"filename": tmpf.name, "observables": {"energy": {}}},
             "walkers": {"population_control": "pair_branch"},
         }
 
@@ -81,11 +78,7 @@ def test_generic_single_det_batch():
         afqmc.run(verbose=False, estimator_filename=tmpf.name)
         afqmc.finalise(verbose=0)
         afqmc.estimators.compute_estimators(
-            comm,
-            afqmc.system,
-            afqmc.hamiltonian,
-            afqmc.trial,
-            afqmc.walkers,
+            comm, afqmc.system, afqmc.hamiltonian, afqmc.trial, afqmc.walkers
         )
         numer_batch = afqmc.estimators["energy"]["ENumer"]
         denom_batch = afqmc.estimators["energy"]["EDenom"]
@@ -159,39 +152,20 @@ def test_generic_single_det_batch_density_diff():
             "verbosity": 0,
             "get_sha1": False,
             "qmc": options,
-            "estimates": {
-                "filename": tmpf.name,
-                "observables": {
-                    "energy": {},
-                },
-            },
+            "estimates": {"filename": tmpf.name, "observables": {"energy": {}}},
             "walkers": {"population_control": "pair_branch"},
         }
-        driver_options["estimates"] = {
-            "filename": tmpf.name,
-            "observables": {
-                "energy": {},
-            },
-        }
+        driver_options["estimates"] = {"filename": tmpf.name, "observables": {"energy": {}}}
         comm = MPI.COMM_WORLD
 
         driver_options["qmc"]["batched"] = True
         afqmc = build_driver_test_instance(
-            nelec,
-            nmo,
-            trial_type="single_det",
-            options=driver_options,
-            seed=7,
-            density_diff=True,
+            nelec, nmo, trial_type="single_det", options=driver_options, seed=7, density_diff=True
         )
         afqmc.run(verbose=False, estimator_filename=tmpf.name)
         afqmc.finalise(verbose=0)
         afqmc.estimators.compute_estimators(
-            comm,
-            afqmc.system,
-            afqmc.hamiltonian,
-            afqmc.trial,
-            afqmc.walkers,
+            comm, afqmc.system, afqmc.hamiltonian, afqmc.trial, afqmc.walkers
         )
 
         numer_batch = afqmc.estimators["energy"]["ENumer"]
@@ -201,18 +175,10 @@ def test_generic_single_det_batch_density_diff():
         data_batch = extract_observable(tmpf.name, "energy")
 
         numpy.random.seed(seed)
-        driver_options["estimates"] = {
-            "filename": tmpf.name,
-            "mixed": {"energy_eval_freq": steps},
-        }
+        driver_options["estimates"] = {"filename": tmpf.name, "mixed": {"energy_eval_freq": steps}}
         driver_options["qmc"]["batched"] = False
         legacy_afqmc = build_legacy_driver_instance(
-            nelec,
-            nmo,
-            trial_type="single_det",
-            options=driver_options,
-            seed=7,
-            density_diff=True,
+            nelec, nmo, trial_type="single_det", options=driver_options, seed=7, density_diff=True
         )
         legacy_afqmc.run(comm=comm, verbose=1)
         legacy_afqmc.finalise(verbose=0)
@@ -266,6 +232,26 @@ def test_generic_single_det_batch_density_diff():
         # assert numpy.mean(data_batch.Overlap.values[:-1].real) == pytest.approx(
         # numpy.mean(data.Overlap.values[:-1].real)
         # )
+
+
+@pytest.mark.driver
+def test_factory_method():
+    with tempfile.NamedTemporaryFile() as hamilf, tempfile.NamedTemporaryFile() as wfnf:
+        numpy.random.seed(7)
+        nmo = 17
+        nelec = (7, 3)
+        nmo = 10
+        naux = 100
+        hcore = numpy.random.random((nmo, nmo))
+        LXmn = numpy.random.random((naux, nmo, nmo))
+        write_hamiltonian(hcore, LXmn, 0.0, filename=hamilf.name)
+        nalpha = nelec[0]
+        nbeta = nelec[1]
+        wfna = numpy.random.random((nmo, nalpha))
+        wfnb = numpy.random.random((nmo, nbeta))
+        wfn = [wfna, wfnb]
+        write_wavefunction(wfn, filename=wfnf.name)
+        AFQMC.build_from_hdf5(hamilf.name, wfnf.name)
 
 
 if __name__ == "__main__":

--- a/ipie/trial_wavefunction/utils.py
+++ b/ipie/trial_wavefunction/utils.py
@@ -57,7 +57,6 @@ def get_trial_wavefunction(
     wfn_type = determine_wavefunction_type(wfn_file)
     if wfn_type == "particle_hole":
         wfn, _ = read_particle_hole_wavefunction(wfn_file)
-        print(wfn[1])
         na = len(wfn[1][0])
         nb = len(wfn[2][0])
         nelec = (na, nb)
@@ -115,8 +114,6 @@ def setup_qmcpack_wavefunction(
     wfn, psi0, nelec = read_qmcpack_wfn_hdf(wfn_file, get_nelec=True)
     nbasis = psi0.shape[0]
     if len(wfn) == 3:
-        na = len(wfn[1])
-        nb = len(wfn[2])
         if ndet_chunks == 1:
             trial = ParticleHoleNonChunked(
                 wfn, nelec, nbasis, num_dets_for_trial=ndets, num_dets_for_props=ndets_props
@@ -135,8 +132,6 @@ def setup_qmcpack_wavefunction(
             nbasis = wfn[1][0].shape[0]
             trial = SingleDet(wfn[1][0], nelec, nbasis)
         else:
-            na = wfn[1][0].shape[-1]
-            nb = wfn[1][0].shape[-1]
             nbasis = wfn[1][0].shape[0]
             trial = NOCI(wfn, nelec, nbasis)
     else:

--- a/ipie/trial_wavefunction/utils.py
+++ b/ipie/trial_wavefunction/utils.py
@@ -57,8 +57,9 @@ def get_trial_wavefunction(
     wfn_type = determine_wavefunction_type(wfn_file)
     if wfn_type == "particle_hole":
         wfn, _ = read_particle_hole_wavefunction(wfn_file)
+        print(wfn[1])
         na = len(wfn[1][0])
-        nb = len(wfn[1][0])
+        nb = len(wfn[2][0])
         nelec = (na, nb)
         if ndet_chunks == 1:
             trial = ParticleHoleNonChunked(
@@ -81,17 +82,21 @@ def get_trial_wavefunction(
             )
     elif wfn_type == "noci":
         wfn, _ = read_noci_wavefunction(wfn_file)
-        assert len(wfn) == 3
-        na = wfn[1].shape[-1]
-        nb = wfn[2].shape[-1]
-        _nbasis = wfn[1].shape[0]
+        ci, (wfna, wfnb) = wfn
+        assert len(wfn) == 2
+        na = wfna.shape[-1]
+        nb = wfnb.shape[-1]
+        _nbasis = wfna.shape[0]
         assert nbasis == _nbasis
-        trial = NOCI(wfn, (na, nb), nbasis)
+        outwfn = np.zeros((wfna.shape[0], wfna.shape[1], na + nb), dtype=wfna.dtype)
+        outwfn[:, :, :na] = wfna.copy()
+        outwfn[:, :, na:] = wfnb.copy()
+        trial = NOCI((ci, outwfn), (na, nb), nbasis)
     elif wfn_type == "single_determinant":
         wfn, _ = read_single_det_wavefunction(wfn_file)
         assert len(wfn) == 2
         na = wfn[0].shape[-1]
-        nb = wfn[0].shape[-1]
+        nb = wfn[1].shape[-1]
         _nbasis = wfn[0].shape[0]
         assert nbasis == _nbasis
         trial = SingleDet(np.hstack(wfn), (na, nb), nbasis)

--- a/ipie/trial_wavefunction/utils.py
+++ b/ipie/trial_wavefunction/utils.py
@@ -32,30 +32,19 @@ from ipie.utils.io import (
 
 
 def get_trial_wavefunction(
-    system,
-    hamiltonian,
+    nbasis: int,
     wfn_file: str,
     ndets: int = -1,
-    ndets_props: int = 1,
+    ndets_props: int = -1,
     ndet_chunks: int = 1,
-    comm=None,
-    scomm=None,
     verbose=False,
 ):
     """Wavefunction factory.
 
     Parameters
     ----------
-    system : class
-        System class.
-    hamiltonian : class
-        Hamiltonian class.
     options : dict
         Trial wavefunction input options.
-    comm : mpi communicator
-        Global MPI communicator
-    scomm : mpi communicator
-        Shared communicator
     verbose : bool
         Print information.
 
@@ -65,82 +54,12 @@ def get_trial_wavefunction(
         Trial wavfunction class.
     """
     assert ndets_props <= ndets
-    assert comm is not None
-    if comm.rank == 0:
-        if verbose:
-            print("# Building trial wavefunction object.")
     wfn_type = determine_wavefunction_type(wfn_file)
     if wfn_type == "particle_hole":
         wfn, _ = read_particle_hole_wavefunction(wfn_file)
-        if ndet_chunks == 1:
-            trial = ParticleHoleNonChunked(
-                wfn,
-                system.nelec,
-                hamiltonian.nbasis,
-                num_dets_for_trial=ndets,
-                num_dets_for_props=ndets_props,
-                verbose=verbose,
-            )
-        else:
-            trial = ParticleHole(
-                wfn,
-                system.nelec,
-                hamiltonian.nbasis,
-                num_dets_for_trial=ndets,
-                num_dets_for_props=ndets_props,
-                num_det_chunks=ndet_chunks,
-                verbose=verbose,
-            )
-    elif wfn_type == "noci":
-        wfn, _ = read_noci_wavefunction(wfn_file)
-        trial = NOCI(
-            wfn,
-            system.nelec,
-            hamiltonian.nbasis,
-        )
-    elif wfn_type == "single_determinant":
-        wfn, _ = read_single_det_wavefunction(wfn_file)
-        trial = SingleDet(
-            np.hstack(wfn),
-            system.nelec,
-            hamiltonian.nbasis,
-        )
-    elif wfn_type == "qmcpack":
-        trial = setup_qmcpack_wavefunction(
-            system.nelec,
-            hamiltonian.nbasis,
-            wfn_file,
-            ndets,
-            ndets_props,
-            ndet_chunks,
-        )
-    else:
-        raise RuntimeError("Unknown wavefunction type")
-    trial.build()
-
-    if verbose:
-        print(f"# Number of determinants in trial wavefunction: {trial.num_dets}")
-    trial.half_rotate(hamiltonian, scomm)
-    trial.calculate_energy(system, hamiltonian)
-    if trial.compute_trial_energy:
-        trial.e1b = comm.bcast(trial.e1b, root=0)
-        trial.e2b = comm.bcast(trial.e2b, root=0)
-    comm.barrier()
-
-    return trial
-
-
-def setup_qmcpack_wavefunction(
-    nelec: tuple,
-    nbasis: int,
-    wfn_file: str,
-    ndets: int,
-    ndets_props: int,
-    ndet_chunks: int,
-) -> TrialWavefunctionBase:
-    wfn, _ = read_qmcpack_wfn_hdf(wfn_file)
-    if len(wfn) == 3:
-        wfn, _ = read_particle_hole_wavefunction(wfn_file)
+        na = len(wfn[1][0])
+        nb = len(wfn[1][0])
+        nelec = (na, nb)
         if ndet_chunks == 1:
             trial = ParticleHoleNonChunked(
                 wfn,
@@ -148,6 +67,54 @@ def setup_qmcpack_wavefunction(
                 nbasis,
                 num_dets_for_trial=ndets,
                 num_dets_for_props=ndets_props,
+                verbose=verbose,
+            )
+        else:
+            trial = ParticleHole(
+                wfn,
+                nelec,
+                nbasis,
+                num_dets_for_trial=ndets,
+                num_dets_for_props=ndets_props,
+                num_det_chunks=ndet_chunks,
+                verbose=verbose,
+            )
+    elif wfn_type == "noci":
+        wfn, _ = read_noci_wavefunction(wfn_file)
+        assert len(wfn) == 3
+        na = wfn[1].shape[-1]
+        nb = wfn[2].shape[-1]
+        _nbasis = wfn[1].shape[0]
+        assert nbasis == _nbasis
+        trial = NOCI(wfn, (na, nb), nbasis)
+    elif wfn_type == "single_determinant":
+        wfn, _ = read_single_det_wavefunction(wfn_file)
+        assert len(wfn) == 2
+        na = wfn[0].shape[-1]
+        nb = wfn[0].shape[-1]
+        _nbasis = wfn[0].shape[0]
+        assert nbasis == _nbasis
+        trial = SingleDet(np.hstack(wfn), (na, nb), nbasis)
+    elif wfn_type == "qmcpack":
+        trial = setup_qmcpack_wavefunction(wfn_file, ndets, ndets_props, ndet_chunks)
+    else:
+        raise RuntimeError("Unknown wavefunction type")
+    trial.build()
+
+    return trial
+
+
+def setup_qmcpack_wavefunction(
+    wfn_file: str, ndets: int, ndets_props: int, ndet_chunks: int
+) -> TrialWavefunctionBase:
+    wfn, psi0, nelec = read_qmcpack_wfn_hdf(wfn_file, get_nelec=True)
+    nbasis = psi0.shape[0]
+    if len(wfn) == 3:
+        na = len(wfn[1])
+        nb = len(wfn[2])
+        if ndet_chunks == 1:
+            trial = ParticleHoleNonChunked(
+                wfn, nelec, nbasis, num_dets_for_trial=ndets, num_dets_for_props=ndets_props
             )
         else:
             trial = ParticleHole(
@@ -160,17 +127,13 @@ def setup_qmcpack_wavefunction(
             )
     elif len(wfn) == 2:
         if len(wfn[0]) == 1:
-            trial = SingleDet(
-                wfn[1][0],
-                nelec,
-                nbasis,
-            )
+            nbasis = wfn[1][0].shape[0]
+            trial = SingleDet(wfn[1][0], nelec, nbasis)
         else:
-            trial = NOCI(
-                wfn,
-                nelec,
-                nbasis,
-            )
+            na = wfn[1][0].shape[-1]
+            nb = wfn[1][0].shape[-1]
+            nbasis = wfn[1][0].shape[0]
+            trial = NOCI(wfn, nelec, nbasis)
     else:
         raise RuntimeError("Unknown QMCPACK wavefunction format.")
     return trial

--- a/ipie/utils/io.py
+++ b/ipie/utils/io.py
@@ -66,6 +66,7 @@ def write_wavefunction(
         write_single_det_wavefunction(wfn, filename, phi0=phi0)
     else:
         if len(wfn) == 3:
+            len(wfn[1][0])
             write_particle_hole_wavefunction(wfn, filename, phi0=phi0)
         elif len(wfn) == 2:
             write_noci_wavefunction(wfn, filename, phi0=phi0)
@@ -158,9 +159,9 @@ def read_particle_hole_wavefunction(
     filename: str,
 ) -> Tuple[Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray], Optional[numpy.ndarray]]:
     with h5py.File(filename, "r") as fh5:
-        ci_coeffs = fh5["ci_coeffs"][:]
-        occ_alpha = fh5["occ_alpha"][:]
-        occ_beta = fh5["occ_beta"][:]
+        ci_coeffs = numpy.array(fh5["ci_coeffs"][:])
+        occ_alpha = numpy.array(fh5["occ_alpha"][:])
+        occ_beta = numpy.array(fh5["occ_beta"][:])
     return (ci_coeffs, occ_alpha, occ_beta), None
 
 
@@ -168,19 +169,19 @@ def read_noci_wavefunction(
     filename: str,
 ) -> Tuple[Tuple[numpy.ndarray, List[numpy.ndarray]], Optional[numpy.ndarray]]:
     with h5py.File(filename, "r") as fh5:
-        ci_coeffs = fh5["ci_coeffs"][:]
-        psia = fh5[f"psi_T_alpha"][:]
-        psib = fh5[f"psi_T_beta"][:]
+        ci_coeffs = numpy.array(fh5["ci_coeffs"][:])
+        psia = numpy.array(fh5[f"psi_T_alpha"][:])
+        psib = numpy.array(fh5[f"psi_T_beta"][:])
     return (ci_coeffs, [psia, psib]), None
 
 
 def read_single_det_wavefunction(filename: str) -> Tuple[List[numpy.ndarray], List[numpy.ndarray]]:
     with h5py.File(filename, "r") as fh5:
-        psia = fh5["psi_T_alpha"][:]
-        phi0a = fh5["phi0_alpha"][:]
+        psia = numpy.array(fh5["psi_T_alpha"][:])
+        phi0a = numpy.array(fh5["phi0_alpha"][:])
         try:
-            psib = fh5["psi_T_beta"][:]
-            phi0b = fh5["phi0_beta"][:]
+            psib = numpy.array(fh5["psi_T_beta"][:])
+            phi0b = numpy.array(fh5["phi0_beta"][:])
             wfn = [psia, psib]
             phi0 = [phi0a, phi0b]
         except KeyError:

--- a/ipie/utils/io.py
+++ b/ipie/utils/io.py
@@ -276,14 +276,14 @@ def read_qmcpack_wfn_hdf(filename, nelec=None, get_nelec=True):
             wgroup = fh5["Wavefunction/NOMSD"]
             wfn, psi0 = read_qmcpack_nomsd_hdf5(wgroup, nelec=nelec)
             if get_nelec:
-                dims = wgroup['dims']
+                dims = wgroup["dims"]
                 nelec = (dims[1], dims[2])
     except KeyError:
         with h5py.File(filename, "r") as fh5:
             wgroup = fh5["Wavefunction/PHMSD"]
             wfn, psi0 = read_qmcpack_phmsd_hdf5(wgroup, nelec=nelec)
             if get_nelec:
-                dims = wgroup['dims']
+                dims = wgroup["dims"]
                 nelec = (dims[1], dims[2])
     except KeyError:
         print("Wavefunction not found.")

--- a/ipie/utils/io.py
+++ b/ipie/utils/io.py
@@ -169,10 +169,8 @@ def read_noci_wavefunction(
 ) -> Tuple[Tuple[numpy.ndarray, List[numpy.ndarray]], Optional[numpy.ndarray]]:
     with h5py.File(filename, "r") as fh5:
         ci_coeffs = fh5["ci_coeffs"][:]
-        ndets = len(ci_coeffs)
-        for _ in range(ndets):
-            psia = fh5[f"psi_T_alpha"][:]
-            psib = fh5[f"psi_T_beta"][:]
+        psia = fh5[f"psi_T_alpha"][:]
+        psib = fh5[f"psi_T_beta"][:]
     return (ci_coeffs, [psia, psib]), None
 
 

--- a/ipie/utils/tests/test_io.py
+++ b/ipie/utils/tests/test_io.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 
 from ipie.utils.io import read_hamiltonian, read_wavefunction, write_hamiltonian, write_wavefunction
+from ipie.utils.testing import get_random_phmsd_opt
 
 
 @pytest.mark.unit
@@ -89,10 +90,7 @@ def test_read_write_particle_hole_wavefunction():
     nmo = 10
     nalpha = 5
     nbeta = 7
-    occa = np.random.randint((ndet, nalpha))
-    occb = np.random.randint((ndet, nbeta))
-    ci_coeffs = np.random.random((ndet))
-    wfn = (ci_coeffs, occa, occb)
+    wfn, _ = get_random_phmsd_opt(nalpha, nbeta, nmo, ndet=ndet)
     with tempfile.NamedTemporaryFile() as tmpfile:
         write_wavefunction(wfn, filename=tmpfile.name)
         wfn_read, _ = read_wavefunction(tmpfile.name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires = [
 
 [tool.black]
 line-length = 100
+exclude = '''/(ipie/legacy)/|(ipie/lib)/'''
 
 [tool.isort]
 profile = 'black'


### PR DESCRIPTION
It's convenient to just build from hdf5 and a bit more elegant to use the driver's factories rather than the boilerplate functions that exist in calc.