### PR TITLE
disabling noci local energy using rchol and enabling the one with chol

### DIFF
--- a/ipie/estimators/local_energy_noci.py
+++ b/ipie/estimators/local_energy_noci.py
@@ -87,8 +87,11 @@ def local_energy_noci_rchol(
     energy[1] += hamiltonian.ecore
     return energy
 
+
 from ipie.estimators.greens_function_single_det import gab_mod_ovlp
 from ipie.estimators.local_energy import local_energy_G
+
+
 def local_energy_noci(
     system: Generic, hamiltonian: GenericRealChol, walkers: UHFWalkersNOCI, trial: NOCI
 ):
@@ -132,8 +135,8 @@ def local_energy_noci(
             energies += weight * e
             denom += weight
         eloc = tuple(energies / denom)
-        energy[iw,0] = eloc[0]
-        energy[iw,1] = eloc[1]
-        energy[iw,2] = eloc[2]
+        energy[iw, 0] = eloc[0]
+        energy[iw, 1] = eloc[1]
+        energy[iw, 2] = eloc[2]
 
     return energy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cython >= 0.29.0
 h5py >= 3.0.0
-numpy >= 1.20.0
+numpy >= 1.20.0, < 1.26.0
 scipy >= 1.3.0, <=1.10.1
 pytest
 pandas == 1.5.1 # issue with pyblock and pandas > 2


### PR DESCRIPTION
It bypasses the need for complex rchol local energy functions for NOCI trial with complex orbitals.
We use real-valued cholesky vectors in that case without half-rotation.