### PR TITLE
Fix wicks assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,20 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest-xdist
+      - name: Install package
+        run: |
+          python -m pip install -e .
       - name: No mpi4py
         run: |
           python -c "from ipie.config import MPI; assert \"FakeComm\" in str(MPI.COMM_WORLD)"
           python -m pytest -n=auto
+      - name: wicks helper
+        run: |
+          sudo apt-get -y update && sudo apt-get -y install cmake
+          cc --version
+          root=$(pwd)
+          cd ipie/lib/wicks && mkdir build && cd build && cmake .. && make VERBOSE=1 && cd $root
+          pytest -sv -m "wicks or unit"
   integration:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,8 @@ jobs:
           cc --version
           root=$(pwd)
           cd ipie/lib/wicks && mkdir build && cd build && cmake .. && make VERBOSE=1 && cd $root
-          pytest -sv -m "wicks or unit"
+          pytest ipie/trial_wavefunction/ -m wicks
+          pytest ipie/lib/wicks -m wicks
   integration:
     strategy:
       fail-fast: false

--- a/ipie/lib/wicks/CMakeLists.txt
+++ b/ipie/lib/wicks/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(wicks_helper SHARED
     ${PROJECT_SOURCE_DIR}/density_matrix.c
     )
 
+set(CMAKE_C_FLAGS "-O3")
 set_target_properties(wicks_helper PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}
     )

--- a/ipie/lib/wicks/determinant_utils.c
+++ b/ipie/lib/wicks/determinant_utils.c
@@ -32,24 +32,21 @@ void encode_det(
     )
 {
   for (int i = 0; i < DET_LEN; i++) {
-    det[i] = 0;
+    det[i] = (u_int64_t)(0);
   }
   u_int64_t mask = 1;
   for (int i = 0; i < nocca; i++) {
     int spin_occ = 2*occa[i];
     int det_ind = spin_occ / DET_SIZE;
     int det_pos = spin_occ % DET_SIZE;
-    /*printf("alpha : %d %d %d\n", spin_occ, det_ind, det_pos);*/
     det[det_ind] |= (mask << det_pos);
   }
   for (int i = 0; i < noccb; i++) {
     int spin_occ = 2*occb[i] + 1;
     int det_ind = spin_occ / DET_SIZE;
     int det_pos = spin_occ % DET_SIZE;
-    /*printf("beta:  %d %d %d\n", spin_occ, det_ind, det_pos);*/
     det[det_ind] |= (mask << det_pos);
   }
-  /*printf("end\n");*/
 }
 
 int count_set_bits(const u_int64_t *det)
@@ -72,7 +69,6 @@ int get_excitation_level(
   int excit_level = 0;
   for (int i = 0; i < DET_LEN; i++) {
       excit_level += count_set_bits_single(deta[i]^detb[i]);
-      /*printf("%d %d %llu %llu %d\n", i, excit_level, deta[i], detb[i], count_set_bits_single(deta[i]^detb[i]));*/
   }
   return excit_level / 2;
 }
@@ -100,16 +96,6 @@ void decode_det(
   }
 }
 
-/*bool is_set(*/
-    /*u_int64_t *det,*/
-    /*int loc*/
-    /*)*/
-/*{*/
-  /*bool set = false;*/
-  /*for (int i = 0; i < DET_LEN; i++) {*/
-    /*set &= det & (loc << diff[0])*/
-  /*}*/
-/*}*/
 
 void build_set_mask(
     u_int64_t *mask,
@@ -154,7 +140,7 @@ void get_ia(
     int* ia)
 {
   int diff[2];
-  u_int64_t delta[2];
+  u_int64_t delta[DET_LEN];
   for (int i = 0; i < DET_LEN; i++) {
     delta[i] = det_bra[i] ^ det_ket[i];
   }
@@ -181,10 +167,10 @@ int get_perm_ia(
   u_int64_t occ_to_count[DET_LEN];
   u_int64_t loc = 1;
   for (int i = 0; i < DET_LEN; i++) {
-    and_mask[i] = 0; // all bits set to 0
-    mask_i[i] = 0; // all bits set to 0
-    mask_a[i] = 0; // all bits set to 0
-    occ_to_count[i] = 0;
+    and_mask[i] = (u_int64_t)(0); // all bits set to 0
+    mask_i[i] = (u_int64_t)(0); // all bits set to 0
+    mask_a[i] = (u_int64_t)(0); // all bits set to 0
+    occ_to_count[i] = (u_int64_t)(0);
   }
   // check bit a is occupied or bit i is unoccupied.
   // else just count set bits between i and a.

--- a/ipie/lib/wicks/determinant_utils.h
+++ b/ipie/lib/wicks/determinant_utils.h
@@ -2,51 +2,19 @@
 
 #include <stdlib.h>
 
-#define DET_LEN   2
+#define DET_LEN 4
 #define DET_SIZE 64
 
-void encode_dets(
-    const int *occsa,
-    const int *occsb,
-    u_int64_t *dets,
-    const size_t nocca,
-    const size_t noccb,
-    const size_t ndet);
-void encode_det(
-    const int *occa,
-    const int *occb,
-    u_int64_t  *det,
-    const size_t nocca,
-    const size_t noccb);
+void encode_dets(const int *occsa, const int *occsb, u_int64_t *dets,
+                 const size_t nocca, const size_t noccb, const size_t ndet);
+void encode_det(const int *occa, const int *occb, u_int64_t *det,
+                const size_t nocca, const size_t noccb);
 int count_set_bits(const u_int64_t *det);
 int count_set_bits_single(const u_int64_t det);
-int get_excitation_level(
-    const u_int64_t *deta,
-    const u_int64_t *detb);
-void decode_det(
-    const u_int64_t *det,
-    int *occs,
-    const size_t nel);
-void get_ia(
-    u_int64_t *det_bra,
-    u_int64_t *det_ket,
-    int *ia);
-int get_perm_ia(
-    u_int64_t *det,
-    int i,
-    int a);
-void bitwise_subtract(
-    u_int64_t *deta,
-    u_int64_t *detb,
-    u_int64_t *result
-    );
-void bitwise_and(
-    u_int64_t *deta,
-    u_int64_t *detb,
-    u_int64_t *result
-    );
-void build_set_mask(
-    u_int64_t *mask,
-    int det_loc,
-    int det_ind);
-
+int get_excitation_level(const u_int64_t *deta, const u_int64_t *detb);
+void decode_det(const u_int64_t *det, int *occs, const size_t nel);
+void get_ia(u_int64_t *det_bra, u_int64_t *det_ket, int *ia);
+int get_perm_ia(u_int64_t *det, int i, int a);
+void bitwise_subtract(u_int64_t *deta, u_int64_t *detb, u_int64_t *result);
+void bitwise_and(u_int64_t *deta, u_int64_t *detb, u_int64_t *result);
+void build_set_mask(u_int64_t *mask, int det_loc, int det_ind);

--- a/ipie/lib/wicks/test_wicks_helper.py
+++ b/ipie/lib/wicks/test_wicks_helper.py
@@ -1,4 +1,3 @@
-
 # Copyright 2022 The ipie Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,100 +19,101 @@ import numpy as np
 import pytest
 
 try:
-    from ipie.lib.wicks.wicks_helper import (compute_opdm, count_set_bits,
-                                             decode_det, encode_det,
-                                             encode_dets, get_excitation_level,
-                                             get_ia, get_perm_ia,
-                                             print_bitstring)
+    from ipie.lib.wicks.wicks_helper import (
+        compute_opdm,
+        count_set_bits,
+        decode_det,
+        encode_det,
+        encode_dets,
+        get_excitation_level,
+        get_ia,
+        get_perm_ia,
+    )
+
     no_wicks = False
-except ImportError:
+except:
     no_wicks = True
+
 
 @pytest.mark.wicks
 @pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
 @pytest.mark.parametrize(
-        "test_input,expected",
-        [
-            (([], [0,1,2,3]), ['0b10101010', '0b0']),
-            (([0,3], [0,1,2,3]), ['0b11101011', '0b0']),
-            (([1], [0,1,2,3]), ['0b10101110', '0b0']),
-            (([], [0,1]), ['0b1010', '0b0']),
-            (([1,35], [0,34]), ['0b110', '0b1100000'])
-        ]
-            )
+    "test_input,expected",
+    [
+        (([], [0, 1, 2, 3]), ["0b10101010", "0b0", "0b0", "0b0"]),
+        (([0, 3], [0, 1, 2, 3]), ["0b11101011", "0b0", "0b0", "0b0"]),
+        (([1], [0, 1, 2, 3]), ["0b10101110", "0b0", "0b0", "0b0"]),
+        (([], [0, 1]), ["0b1010", "0b0", "0b0", "0b0"]),
+        (([0, 32, 64, 96], [1, 33, 65, 97]), ["0b1001", "0b1001", "0b1001", "0b1001"]),
+    ],
+)
 def test_encode_det(test_input, expected):
     a, b = test_input
     a = np.array(a, dtype=np.int32)
     b = np.array(b, dtype=np.int32)
     det = encode_det(a, b)
     for i in range(len(det)):
-        # print(i, bin(det[i]), expected[i])
-        # # print(i, bin(det[i]), expected[i])
         assert bin(det[i]) == expected[i]
+
 
 @pytest.mark.wicks
 @pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
 def test_encode_dets():
-    occsa = np.array(
-            [[0,1,2,3], [0,1,2,4]],
-            dtype=np.int32
-            )
-    occsb = np.array(
-            [[0, 1, 2, 3], [0,1,2,3]],
-            dtype=np.int32
-            )
+    occsa = np.array([[0, 1, 2, 3], [0, 1, 2, 4]], dtype=np.int32)
+    occsb = np.array([[0, 1, 2, 3], [0, 1, 2, 3]], dtype=np.int32)
     dets = encode_dets(occsa, occsb)
     for i in range(len(occsa)):
         d = encode_det(occsa[i], occsb[i])
         assert (dets[i] == d).all()
 
 
-
 @pytest.mark.wicks
 @pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
 @pytest.mark.parametrize(
-        "test_input,expected",
-        [
-            ([15,0], 4),
-            ([37,0], 3),
-            ([1001,0], 7)
-        ]
-            )
+    "test_input,expected",
+    [
+        ([15, 0, 0, 0], 4),
+        ([37, 0, 0, 0], 3),
+        ([1001, 1001, 1001, 1001], 28),
+        ([(1 << 64) - 1] * 4, 64 * 4),
+    ],
+)
 def test_count_set_bits(test_input, expected):
     nset = count_set_bits(np.array(test_input, dtype=np.uint64))
     assert nset == expected
 
-@pytest.mark.wicks
-@pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
-@pytest.mark.parametrize(
-        "test_input,expected",
-        [
-            # (([2,0], [1,0]), 1),
-            # (([12,0], [3,0]), 2),
-            (([1688832680394751, 2], [1125899906842623, 0]), 2)
-        ]
-            )
-def test_get_excitation_level(test_input, expected):
-    # print(bin(test_input[0]), bin(test_input[1]))
-    # print(bin(test_input[0]^test_input[1]))
-    nset = get_excitation_level(
-            np.array(test_input[0], dtype=np.uint64),
-            np.array(test_input[1], dtype=np.uint64)
-            )
-    assert nset == expected
 
 @pytest.mark.wicks
 @pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
 @pytest.mark.parametrize(
-        "test_input,expected",
-        [
-            (np.array([12,0], dtype=np.uint64), [2,3]),
-            (np.array([5,0], dtype=np.uint64), [0,2]),
-        ]
-            )
+    "test_input,expected",
+    [
+        (([2, 0, 0, 0], [1, 0, 0, 0]), 1),
+        (([12, 0, 0, 0], [3, 0, 0, 0]), 2),
+        (([1688832680394751, 2, 0, 0], [1125899906842623, 0, 0, 0]), 2),
+        (([(1 << 64) - 1] * 4, [(1 << 64) - 1] * 3 + [((1 << 64) - 1) >> 8]), 4),
+    ],
+)
+def test_get_excitation_level(test_input, expected):
+    nset = get_excitation_level(
+        np.array(test_input[0], dtype=np.uint64), np.array(test_input[1], dtype=np.uint64)
+    )
+    assert nset == expected
+
+
+@pytest.mark.wicks
+@pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (np.array([12, 0, 0, 0], dtype=np.uint64), [2, 3]),
+        (np.array([5, 0, 0, 0], dtype=np.uint64), [0, 2]),
+        (np.array([5, 0, 0, 0], dtype=np.uint64), [0, 2]),
+        (np.array([(1 << 64) - 1] * 4, dtype=np.uint64), list(range(64 * 4))),
+    ],
+)
 def test_decode_det(test_input, expected):
     out = np.zeros(len(expected), dtype=np.int32)
-    # print(out.size, out.shape, expected, np.array(expected).shape)
     decode_det(test_input, out)
     assert (out == expected).all()
 
@@ -122,52 +122,48 @@ def test_decode_det(test_input, expected):
 @pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
 def test_get_ia():
     # <1100|0^3|1010>
-    ket = encode_det(
-            np.array([], dtype=np.int32),
-            np.array([0,1], dtype=np.int32)
-            )
-    bra = encode_det(
-            np.array([0], dtype=np.int32),
-            np.array([0], dtype=np.int32)
-            )
+    ket = encode_det(np.array([], dtype=np.int32), np.array([0, 1], dtype=np.int32))
+    bra = encode_det(np.array([0], dtype=np.int32), np.array([0], dtype=np.int32))
     ia = np.zeros(2, dtype=np.int32)
     get_ia(bra, ket, ia)
     assert (ia == [3, 0]).all()
+    ket = [(1 << 64) - 1] * 4
+    bra = [(1 << 64) - 1] * 4
+    bra[1] = bra[1] >> 2
+    bra = np.array(bra, dtype=np.uint64)
+    ket = np.array(ket, dtype=np.uint64)
+    get_ia(bra, ket, ia)
+    assert (ia == [126, 127]).all()
+
 
 @pytest.mark.wicks
 @pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
 @pytest.mark.parametrize(
-        "test_input,expected",
-        [
-            ([[], [0,1], [3,0]], -1),
-            ([[0,14//2], [0,9//2], [14, 8]], -1),
-            ([[0,4//2], [1,13//2], [13, 17]], 1),
-        ]
-            )
+    "test_input,expected",
+    [
+        ([[], [0, 1], [3, 0]], -1),
+        ([[0, 14 // 2], [0, 9 // 2], [14, 8]], -1),
+        ([[0, 4 // 2], [1, 13 // 2], [13, 17]], 1),
+    ],
+)
 def test_get_perm_ia(test_input, expected):
     # perm(0^3|0101>) = -1
     # |0101> = 1010 (binary)
     o1, o2, ia = test_input
-    ket = encode_det(
-            np.array(o1, dtype=np.int32),
-            np.array(o2, dtype=np.int32)
-            )
-    print(bin(ket[0]), o1, o2, ia, 2*np.array(ia))
+    ket = encode_det(np.array(o1, dtype=np.int32), np.array(o2, dtype=np.int32))
     perm = get_perm_ia(ket, ia[0], ia[1])
     assert perm == expected
+
 
 @pytest.mark.wicks
 @pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
 def test_get_perm_ia_long():
-    # perm(0^3|0101>) = -1
-    # |0101> = 1010 (binary)
-    ket = np.array([3236962232172543, 0], dtype=np.uint64)
+    ket = np.array([3236962232172543, 0, 0, 0], dtype=np.uint64)
     out = np.zeros(50, dtype=np.int32)
     decode_det(ket, out)
-    print(out)
-    print(bin(ket[0]), 51, 47)
     perm = get_perm_ia(ket, 51, 47)
     assert perm == 1
+
 
 @pytest.mark.wicks
 @pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
@@ -176,25 +172,9 @@ def test_compute_opdm():
     # |0101> = 1010 (binary)
     coeffs = np.array([0.55, 0.1333, 0.001, 0.44])
     dets = []
-    dets.append(encode_det(
-            np.array([0], dtype=np.int32),
-            np.array([0], dtype=np.int32)
-            ))
-    dets.append(encode_det(
-            np.array([0], dtype=np.int32),
-            np.array([1], dtype=np.int32)
-            ))
-    dets.append(encode_det(
-            np.array([1], dtype=np.int32),
-            np.array([0], dtype=np.int32)
-            ))
-    dets.append(encode_det(
-            np.array([1], dtype=np.int32),
-            np.array([1], dtype=np.int32)
-            ))
+    dets.append(encode_det(np.array([0], dtype=np.int32), np.array([0], dtype=np.int32)))
+    dets.append(encode_det(np.array([0], dtype=np.int32), np.array([1], dtype=np.int32)))
+    dets.append(encode_det(np.array([1], dtype=np.int32), np.array([0], dtype=np.int32)))
+    dets.append(encode_det(np.array([1], dtype=np.int32), np.array([1], dtype=np.int32)))
     dets = np.array(dets, dtype=np.ulonglong)
-    P = compute_opdm(
-            coeffs,
-            dets,
-            4,
-            2)
+    P = compute_opdm(coeffs, dets, 4, 2)

--- a/ipie/lib/wicks/wicks_helper.py
+++ b/ipie/lib/wicks/wicks_helper.py
@@ -26,7 +26,7 @@ try:
     _wicks_helper = np.ctypeslib.load_library("libwicks_helper", _path)
 except OSError:
     raise ImportError
-DET_LEN = 2
+DET_LEN = 4
 
 
 def encode_dets(occsa, occsb):
@@ -57,9 +57,7 @@ def encode_dets(occsa, occsb):
     fun.argtypes = [
         ndpointer(shape=(ndets, nocca), dtype=ctypes.c_int, flags="C_CONTIGUOUS"),
         ndpointer(shape=(ndets, noccb), dtype=ctypes.c_int, flags="C_CONTIGUOUS"),
-        ndpointer(
-            shape=(ndets, DET_LEN), dtype=ctypes.c_ulonglong, flags="C_CONTIGUOUS"
-        ),
+        ndpointer(shape=(ndets, DET_LEN), dtype=ctypes.c_ulonglong, flags="C_CONTIGUOUS"),
         ctypes.c_size_t,
         ctypes.c_size_t,
         ctypes.c_size_t,
@@ -102,7 +100,7 @@ def encode_det(a, b):
         ctypes.c_size_t,
     ]
     out = np.zeros(DET_LEN, dtype=np.uint64)
-    det = _wicks_helper.encode_det(a, b, out, a.size, b.size)
+    _wicks_helper.encode_det(a, b, out, a.size, b.size)
     return out
 
 
@@ -121,9 +119,7 @@ def count_set_bits(a):
     """
     fun = _wicks_helper.count_set_bits
     fun.restype = ctypes.c_int
-    fun.argtypes = [
-        ndpointer(shape=(DET_LEN), dtype=ctypes.c_ulonglong, flags="C_CONTIGUOUS")
-    ]
+    fun.argtypes = [ndpointer(shape=(DET_LEN), dtype=ctypes.c_ulonglong, flags="C_CONTIGUOUS")]
     nset = _wicks_helper.count_set_bits(a)
     return nset
 
@@ -174,7 +170,6 @@ def decode_det(det, occs):
         ndpointer(shape=(occs.size), dtype=ctypes.c_int, flags="C_CONTIGUOUS"),
         ctypes.c_size_t,
     ]
-    print(det.size, det.shape, occs.size, occs.shape)
     _wicks_helper.decode_det(det, occs, occs.size)
 
 
@@ -228,7 +223,6 @@ def get_perm_ia(det_ket, i, a):
         ctypes.c_int,
         ctypes.c_int,
     ]
-    # print(det_ket, type(det_ket), det_ket.dtype)
     perm = _wicks_helper.get_perm_ia(det_ket, i, a)
     return perm
 
@@ -257,9 +251,7 @@ def compute_opdm(ci_coeffs, dets, norbs, nelec):
         fun.restype = None
         fun.argtypes = [
             ndpointer(np.complex128, flags="C_CONTIGUOUS"),
-            ndpointer(
-                shape=(ndets, DET_LEN), dtype=ctypes.c_ulonglong, flags="C_CONTIGUOUS"
-            ),
+            ndpointer(shape=(ndets, DET_LEN), dtype=ctypes.c_ulonglong, flags="C_CONTIGUOUS"),
             ndpointer(np.complex128, flags="C_CONTIGUOUS"),
             ndpointer(ctypes.c_int, flags="C_CONTIGUOUS"),
             ctypes.c_size_t,
@@ -271,9 +263,7 @@ def compute_opdm(ci_coeffs, dets, norbs, nelec):
         fun.restype = None
         fun.argtypes = [
             ndpointer(ctypes.c_double, flags="C_CONTIGUOUS"),
-            ndpointer(
-                shape=(ndets, DET_LEN), dtype=ctypes.c_ulonglong, flags="C_CONTIGUOUS"
-            ),
+            ndpointer(shape=(ndets, DET_LEN), dtype=ctypes.c_ulonglong, flags="C_CONTIGUOUS"),
             ndpointer(ctypes.c_double, flags="C_CONTIGUOUS"),
             ndpointer(ctypes.c_int, flags="C_CONTIGUOUS"),
             ctypes.c_size_t,
@@ -306,7 +296,6 @@ def convert_phase(occa, occb):
     ndet = len(occa)
     phases = np.zeros(ndet)
     for i in range(ndet):
-        doubles = list(set(occa[i]) & set(occb[i]))
         occa0 = np.array(occa[i])
         occb0 = np.array(occb[i])
 
@@ -320,11 +309,9 @@ def convert_phase(occa, occb):
     return phases
 
 
-def print_bitstring(bitstring, nbits=64):
+def get_bitstring(bitstring, nbits=64):
     mask = np.uint64(1)
     out = ""
     for bs in bitstring:
-        out += "".join(
-            "1" if bs & (mask << np.uint64(i)) else "0" for i in range(nbits)
-        )
+        out += "".join("1" if bs & (mask << np.uint64(i)) else "0" for i in range(nbits))
     return out[::-1]

--- a/ipie/qmc/afqmc.py
+++ b/ipie/qmc/afqmc.py
@@ -196,6 +196,7 @@ class AFQMC(object):
         stabilize_freq=5,
         pop_control_freq=5,
         num_dets_chunk=1,
+        num_dets_for_trial_props=100,
         pack_cholesky=True,
         verbose=True,
     ) -> "AFQMC":
@@ -228,6 +229,8 @@ class AFQMC(object):
                 steps.) Default 25.
         num_det_chunks : int
             Size of chunks of determinants to process during batching. Default=1 (no batching).
+        num_dets_for_trial_props: int
+            Number of determinants to use to evaluate trial wavefunction properties.
         pack_cholesky : bool
             Use symmetry to reduce memory consumption of integrals. Default True.
         verbose : bool
@@ -239,7 +242,12 @@ class AFQMC(object):
             ham_file, mpi_handler.scomm, verbose=_verbose, pack_chol=pack_cholesky
         )
         trial = get_trial_wavefunction(
-            num_elec, ham.nbasis, wfn_file, ndet_chunks=num_dets_chunk, verbose=_verbose
+            num_elec,
+            ham.nbasis,
+            wfn_file,
+            ndet_chunks=num_dets_chunk,
+            ndets_props=num_dets_for_trial_props,
+            verbose=_verbose,
         )
         trial.half_rotate(ham, mpi_handler.scomm)
         return AFQMC.build(

--- a/ipie/trial_wavefunction/particle_hole.py
+++ b/ipie/trial_wavefunction/particle_hole.py
@@ -49,9 +49,11 @@ class ParticleHole(TrialWavefunctionBase):
         self.setup_basic_wavefunction(
             wfn, num_dets=num_dets_for_trial, use_active_space=use_active_space
         )
-        self._num_dets_for_props = num_dets_for_props
         self._num_dets = len(self.coeffs)
-        self._num_dets_for_props = num_dets_for_props
+        self._num_dets_for_props = (
+            self._num_dets if num_dets_for_props == -1 else num_dets_for_props
+        )
+        self._num_dets_for_props = min(self._num_dets, self._num_dets_for_props)
         self._num_dets_for_trial = num_dets_for_trial
         self._num_det_chunks = num_det_chunks
         self.ortho_expansion = True
@@ -416,6 +418,12 @@ class ParticleHole(TrialWavefunctionBase):
             if self.verbose:
                 print("# Using Wicks helper to compute 1-RDM.")
             assert wicks_helper is not None
+            max_orb = max(np.max(self.occa), np.max(self.occb))
+            err_msg = (
+                f"Number of orbitals is too large for wicks_helper {max_orb} "
+                f"vs {64*wicks_helper.DET_LEN}."
+            )
+            assert 2 * max_orb < 64 * wicks_helper.DET_LEN, err_msg
             dets = wicks_helper.encode_dets(self.occa, self.occb)
             phases = wicks_helper.convert_phase(self.occa, self.occb)
             _keep = self.num_dets_for_props
@@ -430,6 +438,11 @@ class ParticleHole(TrialWavefunctionBase):
                 print(f"# Time to compute 1-RDM: {end - start} s")
         else:
             self.G = self.compute_1rdm(self.nbasis)
+        tr_g = self.G[0].trace() + self.G[1].trace()
+        err_msg = f"Tr(G_T) is incorrect {tr_g} vs {self.nalpha + self.nbeta}"
+        assert np.isclose(tr_g, self.nalpha + self.nbeta), err_msg
+        if self.verbose:
+            print(f"# Tr(G_T): {tr_g}")
 
     def calc_greens_function(self, walkers) -> np.ndarray:
         return greens_function_multi_det_wicks_opt(walkers, self)
@@ -442,7 +455,9 @@ class ParticleHole(TrialWavefunctionBase):
 
     def compute_1rdm(self, nbasis):
         assert self.ortho_expansion == True
-        denom = np.sum(self.coeffs.conj() * self.coeffs)
+        denom = np.sum(
+            self.coeffs[: self.num_dets_for_props].conj() * self.coeffs[: self.num_dets_for_props]
+        )
         Pa = np.zeros((nbasis, nbasis), dtype=np.complex128)
         Pb = np.zeros((nbasis, nbasis), dtype=np.complex128)
         P = [Pa, Pb]
@@ -457,13 +472,13 @@ class ParticleHole(TrialWavefunctionBase):
                 ix = orb - nbasis
             return ix, s
 
-        for idet in range(self.num_dets):
+        for idet in range(self.num_dets_for_props):
             di = self.spin_occs[idet]
             # zero excitation case
             for iorb in range(len(di)):
                 ii, spin_ii = map_orb(di[iorb], nbasis)
                 P[spin_ii][ii, ii] += self.coeffs[idet].conj() * self.coeffs[idet]
-            for jdet in range(idet + 1, self.num_dets):
+            for jdet in range(idet + 1, self.num_dets_for_props):
                 dj = self.spin_occs[jdet]
                 from_orb = list(set(dj) - set(di))
                 to_orb = list(set(di) - set(dj))

--- a/ipie/trial_wavefunction/tests/__init__.py
+++ b/ipie/trial_wavefunction/tests/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 The ipie Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Fionn Malone <fionn.malone@gmail.com>
+#          Joonho Lee
+#

--- a/ipie/trial_wavefunction/tests/test_particle_hole.py
+++ b/ipie/trial_wavefunction/tests/test_particle_hole.py
@@ -2,6 +2,13 @@ import numpy as np
 import pytest
 
 from ipie.config import MPI
+
+try:
+    from ipie.lib.wicks import wicks_helper
+
+    no_wicks = False
+except ImportError:
+    no_wicks = True
 from ipie.trial_wavefunction.particle_hole import (
     ParticleHole,
     ParticleHoleNonChunked,
@@ -30,6 +37,7 @@ def test_wicks_slow():
     assert len(trial.phase_a) == trial.num_dets
     assert len(trial.phase_b) == trial.num_dets
     trial.num_dets = 10
+    trial.num_dets_for_props = 10
     trial.build()
     assert len(trial.cre_a) == trial.num_dets
     assert len(trial.cre_b) == trial.num_dets
@@ -147,3 +155,35 @@ def test_wicks_opt_chunked():
     assert trial._rH1b.shape == (nbeta, nbasis)
     assert trial._rchola_act.shape == (naux, nbasis * trial.nact)
     assert trial._rcholb_act.shape == (naux, nbasis * trial.nact)
+
+
+@pytest.mark.wicks
+@pytest.mark.skipif(no_wicks, reason="lib.wicks not found.")
+@pytest.mark.parametrize(
+    "nalpha,nbeta,nbasis", ((4, 4, 10), (4, 7, 12), (36, 36, 47), (64, 65, 72))
+)
+def test_opt_one_rdm(nalpha, nbeta, nbasis):
+    wavefunction, _ = get_random_phmsd_opt(nalpha, nbeta, nbasis, ndet=100, cmplx_coeffs=False)
+    trial = ParticleHole(
+        wavefunction,
+        (nalpha, nbeta),
+        nbasis,
+        verbose=False,
+        num_dets_for_props=len(wavefunction[0]),
+    )
+    ref = trial.compute_1rdm(nbasis)
+    assert np.allclose(trial.G, ref)
+    wavefunction, _ = get_random_phmsd_opt(
+        nalpha, nbeta, nbasis, ndet=len(wavefunction[0]), cmplx_coeffs=True
+    )
+    trial = ParticleHole(
+        wavefunction,
+        (nalpha, nbeta),
+        nbasis,
+        verbose=False,
+        num_dets_for_props=(len(wavefunction[0])),
+    )
+    ref = trial.compute_1rdm(nbasis)
+    # TODO: Fix convention.
+    assert np.allclose(trial.G[0], ref[0].T)
+    assert np.allclose(trial.G[1], ref[1].T)

--- a/ipie/trial_wavefunction/utils.py
+++ b/ipie/trial_wavefunction/utils.py
@@ -38,7 +38,7 @@ def get_trial_wavefunction(
     nbasis: int,
     wfn_file: str,
     ndets: int = -1,
-    ndets_props: int = -1,
+    ndets_props: int = 100,
     ndet_chunks: int = 1,
     verbose=False,
 ):
@@ -56,7 +56,6 @@ def get_trial_wavefunction(
     trial : class or None
         Trial wavfunction class.
     """
-    assert ndets_props <= ndets
     wfn_type = determine_wavefunction_type(wfn_file)
     if wfn_type == "particle_hole":
         wfn, _ = read_particle_hole_wavefunction(wfn_file)
@@ -103,7 +102,6 @@ def get_trial_wavefunction(
         trial = setup_qmcpack_wavefunction(wfn_file, ndets, ndets_props, ndet_chunks)
     else:
         raise RuntimeError("Unknown wavefunction type")
-    trial.build()
 
     return trial
 

--- a/ipie/utils/testing.py
+++ b/ipie/utils/testing.py
@@ -229,7 +229,7 @@ def get_random_phmsd_opt(nup, ndown, nbasis, ndet=10, init=False, dist=None, cmp
             dets += list(itertools.product(oa, ob))
     occ_a, occ_b = zip(*dets)
     _ndet = min(len(occ_a), ndet)
-    wfn = (coeffs, list(occ_a[:_ndet]), list(occ_b[:_ndet]))
+    wfn = (coeffs[:_ndet], list(occ_a[:_ndet]), list(occ_b[:_ndet]))
     return wfn, init_wfn
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,5 +5,5 @@ markers =
     mpi: mark a test as a MPI intgration test
     wicks: lib file (used to filter out lib until cmake setup)
     gpu: mark a test as a gpu unit test
-addopts = -rs -v -m "unit or driver or mpi" --ignore=ipie/lib
+addopts = -rs -v -m "unit or driver or mpi"
 


### PR DESCRIPTION
Fixes #285. This wasn't a bug per se, more of a case of poor assertions. The optimized variational wavefunction code uses some number (DET_LEN) 64 bit unsigned integers to represent the bitstrings. This was hardcoded to 2 so, the max number of spin orbitals would be 128. If one went beyond this the code wouldn't crash. Here I extend this to 256 and also add an assertion when build the trial wavefunction class. I also added some better unit tests and test the wicks_helper as part of the CI.

This code is hopefully going to go away if I ever get the time.