### PR TITLE
Fix format and lint errors and relax requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         mpi:
           - openmpi
     runs-on:  ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         pip install -r dev/dev.txt
         pip install pyblock
         # https://github.com/JoonhoLee-Group/ipie/issues/278
-        pip install "pyscf<=2.3.0"
+        pip install pyscf
     - name: Install package
       run: |
         # HACK FOR LEGACY CODE!
@@ -134,7 +134,7 @@ jobs:
           pip install -r requirements.txt
           pip install pyblock
           # https://github.com/JoonhoLee-Group/ipie/issues/278
-          pip install "pyscf<=2.3.0" fqe
+          pip install pyscf fqe
       - name: Install package
         run: |
           python -m pip install -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Setup MPI
         uses: mpi4py/setup-mpi@v1
         with:
-          mpi: openmpi 
+          mpi: openmpi
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt 
+          pip install -r requirements.txt
           pip install -r dev/dev.txt
       - name: pylint
         run: |
@@ -108,11 +108,11 @@ jobs:
       - name: Setup MPI
         uses: mpi4py/setup-mpi@v1
         with:
-          mpi: openmpi 
+          mpi: openmpi
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt 
+          pip install -r requirements.txt
           pip install -r dev/dev.txt
       - name: Install package
         run: |
@@ -131,7 +131,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt 
+          pip install -r requirements.txt
           pip install pyblock
           # https://github.com/JoonhoLee-Group/ipie/issues/278
           pip install "pyscf<=2.3.0" fqe

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ ipie/qmc/tests/reference_data/**/*.h5
 *wheels*
 *FCIDUMP*
 *out*
+
+*.code-workspace

--- a/.pylintrc
+++ b/.pylintrc
@@ -23,8 +23,8 @@ output-format=colorized
 disable=all
 enable=
       no-member,
-    # renable once classes are tidied
-;     attribute-defined-outside-init,
+      # renable once classes are tidied
+      # attribute-defined-outside-init,
       consider-using-f-string,
       useless-object-inheritance,
       unused-variable,

--- a/dev/run_tests.py
+++ b/dev/run_tests.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import argparse
 import glob
 import os

--- a/examples/07-custom_trial/run_afqmc.py
+++ b/examples/07-custom_trial/run_afqmc.py
@@ -91,7 +91,7 @@ class NoisyEnergyEstimator(EnergyEstimator):
             trial=trial,
         )
 
-    def compute_estimator(self, system, walkers, hamiltonian, trial, istep=1):
+    def compute_estimator(self, system, walkers, hamiltonian, trial):
         trial.calc_greens_function(walkers)
         # Need to be able to dispatch here
         energy = local_energy_batch(system, hamiltonian, walkers, trial)

--- a/examples/08-custom_walker/run_afqmc.py
+++ b/examples/08-custom_walker/run_afqmc.py
@@ -94,7 +94,7 @@ class NoisyEnergyEstimator(EnergyEstimator):
             trial=trial,
         )
 
-    def compute_estimator(self, system, walkers, hamiltonian, trial, istep=1):
+    def compute_estimator(self, system, walkers, hamiltonian, trial):
         trial.calc_greens_function(walkers)
         # Need to be able to dispatch here
         energy = local_energy_batch(system, hamiltonian, walkers, trial)

--- a/examples/16-ft_afqmc/run_afqmc.py
+++ b/examples/16-ft_afqmc/run_afqmc.py
@@ -1,11 +1,12 @@
 import json
-import numpy
 
+import numpy
 from ueg import UEG
-from ipie.config import MPI
+
 from ipie.addons.thermal.qmc.calc import build_thermal_afqmc_driver
-from ipie.analysis.extraction import extract_observable
 from ipie.analysis.autocorr import reblock_by_autocorr
+from ipie.analysis.extraction import extract_observable
+from ipie.config import MPI
 
 comm = MPI.COMM_WORLD
 
@@ -65,7 +66,7 @@ if verbose:
 # 3. Run thermal AFQMC calculation.
 afqmc.run(verbose=verbose)
 afqmc.finalise()
-afqmc.estimators.compute_estimators(afqmc.hamiltonian, afqmc.trial, afqmc.walkers)
+afqmc.estimators.compute_estimators(hamiltonian=afqmc.hamiltonian, trial=afqmc.trial, walker_batch=afqmc.walkers)
 
 if comm.rank == 0:
     energy_data = extract_observable(afqmc.estimators.filename, "energy")

--- a/ipie/addons/free_projection/estimators/energy.py
+++ b/ipie/addons/free_projection/estimators/energy.py
@@ -30,7 +30,7 @@ class EnergyEstimatorFP(EnergyEstimator):
     ):
         super().__init__(system, ham, trial, filename)
 
-    def compute_estimator(self, system, walkers, hamiltonian, trial, istep=1):
+    def compute_estimator(self, system, walkers, hamiltonian, trial):
         trial.calc_greens_function(walkers)
         # Need to be able to dispatch here
         energy = local_energy(system, hamiltonian, walkers, trial)

--- a/ipie/addons/free_projection/estimators/tests/test_estimators.py
+++ b/ipie/addons/free_projection/estimators/tests/test_estimators.py
@@ -68,8 +68,12 @@ def test_estimator_handler_fp():
         handler["energy1"] = estim
         handler.json_string = ""
         handler.initialize(comm)
-        handler.compute_estimators(comm, system, ham, trial, walker_batch)
-        handler.compute_estimators(comm, system, ham, trial, walker_batch)
+        handler.compute_estimators(
+            system=system, hamiltonian=ham, trial=trial, walker_batch=walker_batch
+        )
+        handler.compute_estimators(
+            system=system, hamiltonian=ham, trial=trial, walker_batch=walker_batch
+        )
 
 
 if __name__ == "__main__":

--- a/ipie/addons/free_projection/qmc/fp_afqmc.py
+++ b/ipie/addons/free_projection/qmc/fp_afqmc.py
@@ -62,7 +62,7 @@ class FPAFQMC(AFQMC):
         trial_wavefunction,
         walkers=None,
         num_walkers: int = 100,
-        seed: int = None,
+        seed: Optional[int] = None,
         num_steps_per_block: int = 25,
         num_blocks: int = 100,
         timestep: float = 0.005,
@@ -282,7 +282,7 @@ class FPAFQMC(AFQMC):
 
     def run(
         self,
-        psi=None,
+        walkers=None,
         estimator_filename="estimate.h5",
         verbose=True,
         additional_estimators: Optional[Dict[str, EstimatorBase]] = None,
@@ -300,8 +300,8 @@ class FPAFQMC(AFQMC):
         """
         self.setup_timers()
         tzero_setup = time.time()
-        if psi is not None:
-            self.walkers = psi
+        if walkers is not None:
+            self.walkers = walkers
         self.setup_timers()
         eshift = 0.0
         self.walkers.orthogonalise()
@@ -360,7 +360,10 @@ class FPAFQMC(AFQMC):
                 start = time.time()
                 if step % self.params.num_steps_per_block == 0:
                     self.estimators[block_number].compute_estimators(
-                        comm, self.system, self.hamiltonian, self.trial, self.walkers
+                        system=self.system,
+                        hamiltonian=self.hamiltonian,
+                        trial=self.trial,
+                        walker_batch=self.walkers,
                     )
                     self.estimators[block_number].print_block(
                         comm,

--- a/ipie/addons/thermal/analysis/extraction.py
+++ b/ipie/addons/thermal/analysis/extraction.py
@@ -19,6 +19,7 @@
 
 from ipie.utils.misc import get_from_dict
 
+
 def set_info(frame, md):
     ncols = len(frame.columns)
     system = md.get("system")
@@ -61,4 +62,3 @@ def set_info(frame, md):
         frame["cholesky_treshold"] = chol
 
     return list(frame.columns[ncols:])
-

--- a/ipie/addons/thermal/estimators/energy.py
+++ b/ipie/addons/thermal/estimators/energy.py
@@ -18,20 +18,19 @@
 
 from typing import Union
 
-from ipie.utils.backend import arraylib as xp
-from ipie.hamiltonians.generic import GenericComplexChol, GenericRealChol
-from ipie.estimators.energy import EnergyEstimator
-
-from ipie.addons.thermal.walkers.uhf_walkers import UHFThermalWalkers
-from ipie.addons.thermal.estimators.thermal import one_rdm_from_G
 from ipie.addons.thermal.estimators.generic import local_energy_generic_cholesky
+from ipie.addons.thermal.estimators.thermal import one_rdm_from_G
+from ipie.addons.thermal.walkers.uhf_walkers import UHFThermalWalkers
+from ipie.estimators.energy import EnergyEstimator
+from ipie.hamiltonians.generic import GenericComplexChol, GenericRealChol
+from ipie.utils.backend import arraylib as xp
 
 
 def local_energy(
-        hamiltonian: Union[GenericRealChol, GenericComplexChol], 
-        walkers: UHFThermalWalkers):
+    hamiltonian: Union[GenericRealChol, GenericComplexChol], walkers: UHFThermalWalkers
+):
     energies = xp.zeros((walkers.nwalkers, 3), dtype=xp.complex128)
-    
+
     for iw in range(walkers.nwalkers):
         # Want the full Green's function when calculating observables.
         walkers.calc_greens_function(iw, slice_ix=walkers.stack[iw].nslice)
@@ -46,9 +45,13 @@ class ThermalEnergyEstimator(EnergyEstimator):
     def __init__(self, system=None, hamiltonian=None, trial=None, filename=None):
         super().__init__(system=system, ham=hamiltonian, trial=trial, filename=filename)
 
-    def compute_estimator(self, walkers, hamiltonian, trial, istep=1):
+    def compute_estimator(self, system=None, walkers=None, hamiltonian=None, trial=None):
         # Need to be able to dispatch here.
         # Re-calculated Green's function in `local_energy`.
+        if hamiltonian is None:
+            raise ValueError("Hamiltonian must not be none.")
+        if walkers is None:
+            raise ValueError("walkers must not be none.")
         energy = local_energy(hamiltonian, walkers)
         self._data["ENumer"] = xp.sum(walkers.weight * energy[:, 0].real)
         self._data["EDenom"] = xp.sum(walkers.weight)

--- a/ipie/addons/thermal/estimators/generic.py
+++ b/ipie/addons/thermal/estimators/generic.py
@@ -50,7 +50,7 @@ def local_energy_generic_cholesky(hamiltonian: GenericRealChol, P):
     Xb = hamiltonian.chol.T.dot(Pb.real.ravel()) + 1.0j * hamiltonian.chol.T.dot(Pb.imag.ravel())
     X = Xa + Xb
     ecoul = 0.5 * numpy.dot(X, X)
-    
+
     # Ex.
     PaT = Pa.T.copy()
     PbT = Pb.T.copy()
@@ -94,7 +94,7 @@ def local_energy_generic_cholesky(hamiltonian: GenericComplexChol, P):
     nbasis = hamiltonian.nbasis
     nchol = hamiltonian.nchol
     Pa, Pb = P[0], P[1]
-    
+
     # Ecoul.
     XAa = hamiltonian.A.T.dot(Pa.ravel())
     XAb = hamiltonian.A.T.dot(Pb.ravel())

--- a/ipie/addons/thermal/estimators/greens_function.py
+++ b/ipie/addons/thermal/estimators/greens_function.py
@@ -19,6 +19,7 @@
 import numpy
 import scipy.linalg
 
+
 def greens_function(A):
     r"""Construct Greens function from density matrix.
 
@@ -50,7 +51,7 @@ def greens_function(A):
 
 
 def greens_function_qr_strat(walkers, iw, slice_ix=None, inplace=True):
-    """Compute the Green's function for walker with index `iw` at time 
+    """Compute the Green's function for walker with index `iw` at time
     `slice_ix`. Uses the Stratification method (DOI 10.1109/IPDPS.2012.37)
     """
     stack_iw = walkers.stack[iw]
@@ -119,18 +120,22 @@ def greens_function_qr_strat(walkers, iw, slice_ix=None, inplace=True):
         if inplace:
             if spin == 0:
                 walkers.Ga[iw] = numpy.dot(
-                    numpy.dot(T1inv, Cinv), numpy.einsum("ii,ij->ij", Db, Q1.conj().T))
+                    numpy.dot(T1inv, Cinv), numpy.einsum("ii,ij->ij", Db, Q1.conj().T)
+                )
             else:
                 walkers.Gb[iw] = numpy.dot(
-                    numpy.dot(T1inv, Cinv), numpy.einsum("ii,ij->ij", Db, Q1.conj().T))
+                    numpy.dot(T1inv, Cinv), numpy.einsum("ii,ij->ij", Db, Q1.conj().T)
+                )
 
         else:
             if spin == 0:
                 Ga_iw = numpy.dot(
-                    numpy.dot(T1inv, Cinv), numpy.einsum("ii,ij->ij", Db, Q1.conj().T))
+                    numpy.dot(T1inv, Cinv), numpy.einsum("ii,ij->ij", Db, Q1.conj().T)
+                )
 
             else:
                 Gb_iw = numpy.dot(
-                    numpy.dot(T1inv, Cinv), numpy.einsum("ii,ij->ij", Db, Q1.conj().T))
+                    numpy.dot(T1inv, Cinv), numpy.einsum("ii,ij->ij", Db, Q1.conj().T)
+                )
 
     return Ga_iw, Gb_iw

--- a/ipie/addons/thermal/estimators/local_energy.py
+++ b/ipie/addons/thermal/estimators/local_energy.py
@@ -25,10 +25,12 @@ from ipie.addons.thermal.trial.mean_field import MeanField
 from ipie.addons.thermal.estimators.generic import local_energy_generic_cholesky
 from ipie.addons.thermal.estimators.thermal import one_rdm_from_G
 
+
 def local_energy_from_density_matrix(
-        hamiltonian: Union[GenericRealChol, GenericComplexChol], 
-        trial: Union[OneBody, MeanField], 
-        P: numpy.ndarray):
+    hamiltonian: Union[GenericRealChol, GenericComplexChol],
+    trial: Union[OneBody, MeanField],
+    P: numpy.ndarray,
+):
     """Compute local energy from a given density matrix P.
 
     Parameters
@@ -47,6 +49,7 @@ def local_energy_from_density_matrix(
     """
     assert len(P) == 2
     return local_energy_generic_cholesky(hamiltonian, P)
+
 
 def local_energy(hamiltonian, walker, trial):
     return local_energy_from_density_matrix(hamiltonian, trial, one_rdm_from_G(walker.G))

--- a/ipie/addons/thermal/estimators/particle_number.py
+++ b/ipie/addons/thermal/estimators/particle_number.py
@@ -17,9 +17,10 @@
 #
 
 import numpy
-from ipie.utils.backend import arraylib as xp
-from ipie.estimators.estimator_base import EstimatorBase
+
 from ipie.addons.thermal.estimators.thermal import one_rdm_from_G
+from ipie.estimators.estimator_base import EstimatorBase
+from ipie.utils.backend import arraylib as xp
 
 
 def particle_number(dmat: numpy.ndarray):
@@ -64,12 +65,13 @@ class ThermalNumberEstimator(EstimatorBase):
         # Must specify that we're dealing with array valued estimator.
         self.scalar_estimator = True
 
-    def compute_estimator(self, walkers, hamiltonian, trial):
+    def compute_estimator(self, system=None, walkers=None, hamiltonian=None, trial=None):
+        if walkers is None:
+            raise ValueError("Walkers cannot be none in estimator.")
         for iw in range(walkers.nwalkers):
             # Want the full Green's function when calculating observables.
             walkers.calc_greens_function(iw, slice_ix=walkers.stack[iw].nslice)
-            nav_iw = particle_number(one_rdm_from_G(
-                        xp.array([walkers.Ga[iw], walkers.Gb[iw]])))
+            nav_iw = particle_number(one_rdm_from_G(xp.array([walkers.Ga[iw], walkers.Gb[iw]])))
             self._data["NavNumer"] += walkers.weight[iw] * nav_iw.real
 
         self._data["NavDenom"] = sum(walkers.weight)

--- a/ipie/addons/thermal/estimators/tests/__init__.py
+++ b/ipie/addons/thermal/estimators/tests/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/ipie/addons/thermal/estimators/tests/test_generic_complex.py
+++ b/ipie/addons/thermal/estimators/tests/test_generic_complex.py
@@ -33,7 +33,7 @@ nelec = (nup, ndown)
 nbasis = 10
 
 # Thermal AFQMC params.
-mu = -10.
+mu = -10.0
 beta = 0.1
 timestep = 0.01
 nwalkers = 12
@@ -46,29 +46,43 @@ verbose = True
 seed = 7
 numpy.random.seed(seed)
 
+
 @pytest.mark.unit
 def test_local_energy_vs_real():
     # Test.
     objs = build_generic_test_case_handlers(
-            nelec, nbasis, mu, beta, timestep, nwalkers=nwalkers, lowrank=lowrank, 
-            mf_trial=mf_trial, complex_integrals=complex_integrals, debug=debug, 
-            seed=seed, verbose=verbose)
-    trial = objs['trial']
-    walkers = objs['walkers']
-    hamiltonian = objs['hamiltonian']
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    walkers = objs["walkers"]
+    hamiltonian = objs["hamiltonian"]
 
     assert isinstance(hamiltonian, GenericRealChol)
-    
+
     chol = hamiltonian.chol
     cx_chol = numpy.array(chol, dtype=numpy.complex128)
     cx_hamiltonian = HamGeneric(
-        numpy.array(hamiltonian.H1, dtype=numpy.complex128), cx_chol, 
-                    hamiltonian.ecore, verbose=False)
+        numpy.array(hamiltonian.H1, dtype=numpy.complex128),
+        cx_chol,
+        hamiltonian.ecore,
+        verbose=False,
+    )
 
     assert isinstance(cx_hamiltonian, GenericComplexChol)
-    
+
     for iw in range(walkers.nwalkers):
-        P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]])) 
+        P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]]))
         energy = local_energy_generic_cholesky(hamiltonian, P)
         cx_energy = local_energy_generic_cholesky(cx_hamiltonian, P)
         numpy.testing.assert_allclose(energy, cx_energy, atol=1e-10)
@@ -78,45 +92,56 @@ def test_local_energy_vs_real():
 def test_local_energy_vs_eri():
     # Test.
     objs = build_generic_test_case_handlers(
-            nelec, nbasis, mu, beta, timestep, nwalkers=nwalkers, lowrank=lowrank, 
-            mf_trial=mf_trial, debug=debug, complex_integrals=True, with_eri=True,
-            seed=seed, verbose=verbose)
-    trial = objs['trial']
-    walkers = objs['walkers']
-    hamiltonian = objs['hamiltonian']
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        debug=debug,
+        complex_integrals=True,
+        with_eri=True,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    walkers = objs["walkers"]
+    hamiltonian = objs["hamiltonian"]
     assert isinstance(hamiltonian, GenericComplexChol)
-    eri = objs['eri'].reshape(nbasis, nbasis, nbasis, nbasis)
-    
+    eri = objs["eri"].reshape(nbasis, nbasis, nbasis, nbasis)
+
     chol = hamiltonian.chol.copy()
     nchol = chol.shape[1]
     chol = chol.reshape(nbasis, nbasis, nchol)
 
     # Check if chol and eri are consistent.
-    eri_chol = numpy.einsum('mnx,slx->mnls', chol, chol.conj())
+    eri_chol = numpy.einsum("mnx,slx->mnls", chol, chol.conj())
     numpy.testing.assert_allclose(eri, eri_chol, atol=1e-10)
 
     for iw in range(walkers.nwalkers):
-        P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]])) 
+        P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]]))
         Pa, Pb = P
         Ptot = Pa + Pb
         etot, e1, e2 = local_energy_generic_cholesky(hamiltonian, P)
 
         # Test 1-body term.
         h1e = hamiltonian.H1[0]
-        e1ref = numpy.einsum('ij,ij->', h1e, Ptot)
+        e1ref = numpy.einsum("ij,ij->", h1e, Ptot)
         numpy.testing.assert_allclose(e1, e1ref, atol=1e-10)
 
         # Test 2-body term.
-        ecoul = 0.5 * numpy.einsum('ijkl,ij,kl->', eri, Ptot, Ptot)
-        exx = -0.5 * numpy.einsum('ijkl,il,kj->', eri, Pa, Pa)
-        exx -= 0.5 * numpy.einsum('ijkl,il,kj->', eri, Pb, Pb)
+        ecoul = 0.5 * numpy.einsum("ijkl,ij,kl->", eri, Ptot, Ptot)
+        exx = -0.5 * numpy.einsum("ijkl,il,kj->", eri, Pa, Pa)
+        exx -= 0.5 * numpy.einsum("ijkl,il,kj->", eri, Pb, Pb)
         e2ref = ecoul + exx
         numpy.testing.assert_allclose(e2, e2ref, atol=1e-10)
-        
+
         etotref = e1ref + e2ref
         numpy.testing.assert_allclose(etot, etotref, atol=1e-10)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_local_energy_vs_real()
     test_local_energy_vs_eri()

--- a/ipie/addons/thermal/estimators/thermal.py
+++ b/ipie/addons/thermal/estimators/thermal.py
@@ -19,6 +19,7 @@
 import numpy
 import scipy.linalg
 
+
 def one_rdm_from_G(G):
     r"""Compute one-particle reduced density matrix from Green's function.
 
@@ -37,6 +38,7 @@ def one_rdm_from_G(G):
     """
     I = numpy.identity(G.shape[-1])
     return numpy.array([I - G[0].T, I - G[1].T], dtype=numpy.complex128)
+
 
 def one_rdm_stable(BT, num_slices):
     nbasis = BT.shape[-1]

--- a/ipie/addons/thermal/propagation/force_bias.py
+++ b/ipie/addons/thermal/propagation/force_bias.py
@@ -23,6 +23,7 @@ from ipie.hamiltonians.generic import GenericRealChol, GenericComplexChol
 from ipie.addons.thermal.estimators.thermal import one_rdm_from_G
 from ipie.utils.backend import arraylib as xp
 
+
 @plum.dispatch
 def construct_force_bias(hamiltonian: GenericRealChol, walkers):
     r"""Compute optimal force bias.
@@ -69,4 +70,3 @@ def construct_force_bias(hamiltonian: GenericComplexChol, walkers):
         vbias[iw, nchol:] = hamiltonian.B.T.dot(P[0].ravel()) + hamiltonian.B.T.dot(P[1].ravel())
 
     return vbias
-

--- a/ipie/addons/thermal/propagation/operations.py
+++ b/ipie/addons/thermal/propagation/operations.py
@@ -18,6 +18,7 @@
 
 from ipie.utils.backend import arraylib as xp
 
+
 def apply_exponential(VHS, exp_nmax):
     """Apply exponential propagator of the HS transformation
 
@@ -42,4 +43,4 @@ def apply_exponential(VHS, exp_nmax):
         Temp = VHS.dot(Temp) / n
         phi += Temp
 
-    return phi # Shape (nbasis, nbasis).
+    return phi  # Shape (nbasis, nbasis).

--- a/ipie/addons/thermal/propagation/phaseless_generic.py
+++ b/ipie/addons/thermal/propagation/phaseless_generic.py
@@ -28,20 +28,18 @@ class PhaselessGeneric(PhaselessBase):
 
     def __init__(self, time_step, mu, exp_nmax=6, lowrank=False, verbose=False):
         super().__init__(time_step, mu, lowrank=lowrank, exp_nmax=exp_nmax, verbose=verbose)
-    
+
     @plum.dispatch
     def construct_VHS(self, hamiltonian: GenericRealChol, xshifted: xp.ndarray):
-        """Includes `nwalkers`.
-        """
-        nwalkers = xshifted.shape[-1] # Shape (nfields, nwalkers).
-        VHS = hamiltonian.chol.dot(xshifted) # Shape (nbasis^2, nwalkers).
+        """Includes `nwalkers`."""
+        nwalkers = xshifted.shape[-1]  # Shape (nfields, nwalkers).
+        VHS = hamiltonian.chol.dot(xshifted)  # Shape (nbasis^2, nwalkers).
         VHS = self.isqrt_dt * VHS.T.reshape(nwalkers, hamiltonian.nbasis, hamiltonian.nbasis)
-        return VHS # Shape (nwalkers, nbasis, nbasis).
-    
+        return VHS  # Shape (nwalkers, nbasis, nbasis).
+
     @plum.dispatch
     def construct_VHS(self, hamiltonian: GenericComplexChol, xshifted: xp.ndarray):
-        """Includes `nwalkers`.
-        """
+        """Includes `nwalkers`."""
         nwalkers = xshifted.shape[-1]
         nchol = hamiltonian.nchol
         VHS = self.isqrt_dt * (

--- a/ipie/addons/thermal/propagation/tests/test_prop_generic.py
+++ b/ipie/addons/thermal/propagation/tests/test_prop_generic.py
@@ -22,6 +22,7 @@ import pytest
 try:
     from ipie.addons.thermal.utils.legacy_testing import build_legacy_generic_test_case_handlers
     from ipie.addons.thermal.utils.legacy_testing import legacy_propagate_walkers
+
     _no_cython = False
 
 except ModuleNotFoundError:
@@ -32,7 +33,9 @@ from ipie.addons.thermal.estimators.generic import local_energy_generic_cholesky
 from ipie.addons.thermal.estimators.thermal import one_rdm_from_G
 from ipie.addons.thermal.utils.testing import build_generic_test_case_handlers
 
-from ipie.legacy.estimators.generic import local_energy_generic_cholesky as legacy_local_energy_generic_cholesky
+from ipie.legacy.estimators.generic import (
+    local_energy_generic_cholesky as legacy_local_energy_generic_cholesky,
+)
 from ipie.legacy.estimators.thermal import one_rdm_from_G as legacy_one_rdm_from_G
 
 comm = MPI.COMM_WORLD
@@ -44,7 +47,7 @@ nelec = (nup, ndown)
 nbasis = 10
 
 # Thermal AFQMC params.
-mu = -10.
+mu = -10.0
 beta = 0.1
 timestep = 0.01
 nwalkers = 12
@@ -63,71 +66,129 @@ numpy.random.seed(seed)
 @pytest.mark.unit
 def test_mf_shift():
     # Test.
-    objs =  build_generic_test_case_handlers(
-            nelec, nbasis, mu, beta, timestep, nwalkers=nwalkers, lowrank=lowrank, 
-            mf_trial=mf_trial, complex_integrals=complex_integrals, debug=debug, 
-            seed=seed, verbose=verbose)
-    hamiltonian = objs['hamiltonian']
-    propagator = objs['propagator']
+    objs = build_generic_test_case_handlers(
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    hamiltonian = objs["hamiltonian"]
+    propagator = objs["propagator"]
 
     # Legacy.
     legacy_objs = build_legacy_generic_test_case_handlers(
-                    hamiltonian, comm, nelec, mu, beta, timestep, 
-                    nwalkers=nwalkers, lowrank=lowrank, mf_trial=mf_trial,
-                    seed=seed, verbose=verbose)
-    legacy_propagator = legacy_objs['propagator']
+        hamiltonian,
+        comm,
+        nelec,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_propagator = legacy_objs["propagator"]
 
-    numpy.testing.assert_almost_equal(legacy_propagator.propagator.mf_shift, 
-                                      propagator.mf_shift, decimal=10)
+    numpy.testing.assert_almost_equal(
+        legacy_propagator.propagator.mf_shift, propagator.mf_shift, decimal=10
+    )
 
 
 @pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
 @pytest.mark.unit
 def test_BH1():
     # Test.
-    objs =  build_generic_test_case_handlers(
-            nelec, nbasis, mu, beta, timestep, nwalkers=nwalkers, lowrank=lowrank, 
-            mf_trial=mf_trial, complex_integrals=complex_integrals, debug=debug, 
-            seed=seed, verbose=verbose)
-    hamiltonian = objs['hamiltonian']
-    propagator = objs['propagator']
+    objs = build_generic_test_case_handlers(
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    hamiltonian = objs["hamiltonian"]
+    propagator = objs["propagator"]
 
     # Legacy.
     legacy_objs = build_legacy_generic_test_case_handlers(
-                    hamiltonian, comm, nelec, mu, beta, timestep, 
-                    nwalkers=nwalkers, lowrank=lowrank, mf_trial=mf_trial,
-                    seed=seed, verbose=verbose)
-    legacy_propagator = legacy_objs['propagator']
+        hamiltonian,
+        comm,
+        nelec,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_propagator = legacy_objs["propagator"]
 
-    numpy.testing.assert_almost_equal(legacy_propagator.propagator.BH1, 
-                                      propagator.BH1, decimal=10)
+    numpy.testing.assert_almost_equal(legacy_propagator.propagator.BH1, propagator.BH1, decimal=10)
 
 
 @pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
 @pytest.mark.unit
 def test_construct_two_body_propagator():
     # Test.
-    objs =  build_generic_test_case_handlers(
-            nelec, nbasis, mu, beta, timestep, nwalkers=nwalkers, lowrank=lowrank, 
-            mf_trial=mf_trial, complex_integrals=complex_integrals, debug=debug, 
-            seed=seed, verbose=verbose)
-    trial = objs['trial']
-    hamiltonian = objs['hamiltonian']
-    walkers = objs['walkers']
-    propagator = objs['propagator']
+    objs = build_generic_test_case_handlers(
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    hamiltonian = objs["hamiltonian"]
+    walkers = objs["walkers"]
+    propagator = objs["propagator"]
 
     # Legacy.
     legacy_objs = build_legacy_generic_test_case_handlers(
-                    hamiltonian, comm, nelec, mu, beta, timestep, 
-                    nwalkers=nwalkers, lowrank=lowrank, mf_trial=mf_trial,
-                    seed=seed, verbose=verbose)
-    legacy_trial = legacy_objs['trial']
-    legacy_hamiltonian = legacy_objs['hamiltonian']
-    legacy_walkers = legacy_objs['walkers']
-    legacy_propagator = legacy_objs['propagator']
-    
+        hamiltonian,
+        comm,
+        nelec,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_trial = legacy_objs["trial"]
+    legacy_hamiltonian = legacy_objs["hamiltonian"]
+    legacy_walkers = legacy_objs["walkers"]
+    legacy_propagator = legacy_objs["propagator"]
+
     cmf, cfb, xshifted, VHS = propagator.construct_two_body_propagator(
-                                walkers, hamiltonian, trial, debug=True)
+        walkers, hamiltonian, trial, debug=True
+    )
 
     legacy_cmf = []
     legacy_cfb = []
@@ -136,13 +197,13 @@ def test_construct_two_body_propagator():
 
     for iw in range(walkers.nwalkers):
         _cmf, _cfb, _xshifted, _VHS = legacy_propagator.two_body_propagator(
-                                        legacy_walkers.walkers[iw], legacy_hamiltonian, 
-                                        legacy_trial, xi=propagator.xi[iw])
+            legacy_walkers.walkers[iw], legacy_hamiltonian, legacy_trial, xi=propagator.xi[iw]
+        )
         legacy_cmf.append(_cmf)
         legacy_cfb.append(_cfb)
         legacy_xshifted.append(_xshifted)
         legacy_VHS.append(_VHS)
-    
+
     legacy_xshifted = numpy.array(legacy_xshifted).T
 
     numpy.testing.assert_almost_equal(legacy_cmf, cmf, decimal=10)
@@ -155,46 +216,72 @@ def test_construct_two_body_propagator():
 @pytest.mark.unit
 def test_phaseless_generic_propagator():
     # Test.
-    objs =  build_generic_test_case_handlers(
-            nelec, nbasis, mu, beta, timestep, nwalkers=nwalkers, lowrank=lowrank, 
-            mf_trial=mf_trial, complex_integrals=complex_integrals, debug=debug, 
-            seed=seed, verbose=verbose)
-    trial = objs['trial']
-    hamiltonian = objs['hamiltonian']
-    walkers = objs['walkers']
-    propagator = objs['propagator']
+    objs = build_generic_test_case_handlers(
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    hamiltonian = objs["hamiltonian"]
+    walkers = objs["walkers"]
+    propagator = objs["propagator"]
 
     # Legacy.
     legacy_objs = build_legacy_generic_test_case_handlers(
-                    hamiltonian, comm, nelec, mu, beta, timestep, 
-                    nwalkers=nwalkers, lowrank=lowrank, mf_trial=mf_trial,
-                    seed=seed, verbose=verbose)
-    legacy_system = legacy_objs['system']
-    legacy_trial = legacy_objs['trial']
-    legacy_hamiltonian = legacy_objs['hamiltonian']
-    legacy_walkers = legacy_objs['walkers']
-    legacy_propagator = legacy_objs['propagator']
+        hamiltonian,
+        comm,
+        nelec,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_system = legacy_objs["system"]
+    legacy_trial = legacy_objs["trial"]
+    legacy_hamiltonian = legacy_objs["hamiltonian"]
+    legacy_walkers = legacy_objs["walkers"]
+    legacy_propagator = legacy_objs["propagator"]
 
     for t in range(walkers.stack[0].nslice):
         for iw in range(walkers.nwalkers):
-            P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]])) 
+            P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]]))
             eloc = local_energy_generic_cholesky(hamiltonian, P)
 
             legacy_P = legacy_one_rdm_from_G(numpy.array(legacy_walkers.walkers[iw].G))
             legacy_eloc = legacy_local_energy_generic_cholesky(
-                            legacy_system, legacy_hamiltonian, legacy_P)
+                legacy_system, legacy_hamiltonian, legacy_P
+            )
 
             numpy.testing.assert_almost_equal(legacy_eloc, eloc, decimal=10)
             numpy.testing.assert_allclose(legacy_walkers.walkers[iw].G[0], walkers.Ga[iw])
-            numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].G[1], walkers.Gb[iw], decimal=10)
+            numpy.testing.assert_almost_equal(
+                legacy_walkers.walkers[iw].G[1], walkers.Gb[iw], decimal=10
+            )
             numpy.testing.assert_almost_equal(legacy_P, P, decimal=10)
-            numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].stack.ovlp[0], walkers.stack[iw].ovlp[0], decimal=10)
-            numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].stack.ovlp[1], walkers.stack[iw].ovlp[1], decimal=10)
+            numpy.testing.assert_almost_equal(
+                legacy_walkers.walkers[iw].stack.ovlp[0], walkers.stack[iw].ovlp[0], decimal=10
+            )
+            numpy.testing.assert_almost_equal(
+                legacy_walkers.walkers[iw].stack.ovlp[1], walkers.stack[iw].ovlp[1], decimal=10
+            )
 
         propagator.propagate_walkers(walkers, hamiltonian, trial, debug=True)
         legacy_walkers = legacy_propagate_walkers(
-                            legacy_hamiltonian, legacy_trial, legacy_walkers, 
-                            legacy_propagator, xi=propagator.xi)
+            legacy_hamiltonian, legacy_trial, legacy_walkers, legacy_propagator, xi=propagator.xi
+        )
 
 
 if __name__ == "__main__":

--- a/ipie/addons/thermal/propagation/tests/ueg/test_prop_ueg.py
+++ b/ipie/addons/thermal/propagation/tests/ueg/test_prop_ueg.py
@@ -23,6 +23,7 @@ try:
     from ipie.addons.thermal.utils.legacy_testing import build_legacy_ueg_test_case_handlers
     from ipie.addons.thermal.utils.legacy_testing import legacy_propagate_walkers
     from ipie.legacy.estimators.ueg import local_energy_ueg as legacy_local_energy_ueg
+
     _no_cython = False
 
 except ModuleNotFoundError:
@@ -45,62 +46,82 @@ def test_phaseless_ueg_propagator():
     nup = 7
     ndown = 7
     nelec = (nup, ndown)
-    rs = 1.
-    ecut = 1.
+    rs = 1.0
+    ecut = 1.0
 
     # Thermal AFQMC params.
-    mu = -1.
+    mu = -1.0
     beta = 0.1
     timestep = 0.01
     nwalkers = 1
     lowrank = False
-    
+
     debug = True
     verbose = False if (comm.rank != 0) else True
     seed = 7
     numpy.random.seed(seed)
-    
+
     # Test.
-    objs =  build_ueg_test_case_handlers(
-            nelec, rs, ecut, mu, beta, timestep, nwalkers=nwalkers, 
-            lowrank=lowrank, debug=debug, seed=seed, verbose=verbose)
-    trial = objs['trial']
-    hamiltonian = objs['hamiltonian']
-    walkers = objs['walkers']
-    propagator = objs['propagator']
+    objs = build_ueg_test_case_handlers(
+        nelec,
+        rs,
+        ecut,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    hamiltonian = objs["hamiltonian"]
+    walkers = objs["walkers"]
+    propagator = objs["propagator"]
 
     # Legacy.
     legacy_objs = build_legacy_ueg_test_case_handlers(
-                    comm, nelec, rs, ecut, mu, beta, timestep, nwalkers=nwalkers, 
-                    lowrank=lowrank, seed=seed, verbose=verbose)
-    legacy_system = legacy_objs['system']
-    legacy_trial = legacy_objs['trial']
-    legacy_hamiltonian = legacy_objs['hamiltonian']
-    legacy_walkers = legacy_objs['walkers']
-    legacy_propagator = legacy_objs['propagator']
+        comm,
+        nelec,
+        rs,
+        ecut,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_system = legacy_objs["system"]
+    legacy_trial = legacy_objs["trial"]
+    legacy_hamiltonian = legacy_objs["hamiltonian"]
+    legacy_walkers = legacy_objs["walkers"]
+    legacy_propagator = legacy_objs["propagator"]
 
     h1e = legacy_hamiltonian.H1[0]
     eri = legacy_hamiltonian.eri_4()
 
     for t in range(walkers.stack[0].nslice):
         for iw in range(walkers.nwalkers):
-            P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]])) 
+            P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]]))
             eloc = local_energy_generic_cholesky(hamiltonian, P)
 
             legacy_P = legacy_one_rdm_from_G(numpy.array(legacy_walkers.walkers[iw].G))
             legacy_eloc = legacy_local_energy_ueg(legacy_system, legacy_hamiltonian, legacy_P)
-            
+
             legacy_Pa, legacy_Pb = legacy_P
             legacy_Ptot = legacy_Pa + legacy_Pb
-            ref_e1 = numpy.einsum('ij,ij->', h1e, legacy_Ptot)
+            ref_e1 = numpy.einsum("ij,ij->", h1e, legacy_Ptot)
 
             Ptot = legacy_Ptot
             Pa = legacy_Pa
             Pb = legacy_Pb
 
-            ecoul = 0.5 * numpy.einsum('ijkl,ij,kl->', eri, Ptot, Ptot)
-            exx = -0.5 * numpy.einsum('ijkl,il,kj->', eri, Pa, Pa)
-            exx -= 0.5 * numpy.einsum('ijkl,il,kj->', eri, Pb, Pb)
+            ecoul = 0.5 * numpy.einsum("ijkl,ij,kl->", eri, Ptot, Ptot)
+            exx = -0.5 * numpy.einsum("ijkl,il,kj->", eri, Pa, Pa)
+            exx -= 0.5 * numpy.einsum("ijkl,il,kj->", eri, Pb, Pb)
             ref_e2 = ecoul + exx
             ref_eloc = (ref_e1 + ref_e2, ref_e1, ref_e2)
 
@@ -110,15 +131,23 @@ def test_phaseless_ueg_propagator():
             numpy.testing.assert_allclose(legacy_eloc, ref_eloc, atol=1e-10)
             numpy.testing.assert_almost_equal(legacy_eloc, eloc, decimal=10)
 
-            numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].G[0], walkers.Ga[iw], decimal=10)
-            numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].G[1], walkers.Gb[iw], decimal=10)
-            numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].stack.ovlp[0], walkers.stack[iw].ovlp[0], decimal=10)
-            numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].stack.ovlp[1], walkers.stack[iw].ovlp[1], decimal=10)
+            numpy.testing.assert_almost_equal(
+                legacy_walkers.walkers[iw].G[0], walkers.Ga[iw], decimal=10
+            )
+            numpy.testing.assert_almost_equal(
+                legacy_walkers.walkers[iw].G[1], walkers.Gb[iw], decimal=10
+            )
+            numpy.testing.assert_almost_equal(
+                legacy_walkers.walkers[iw].stack.ovlp[0], walkers.stack[iw].ovlp[0], decimal=10
+            )
+            numpy.testing.assert_almost_equal(
+                legacy_walkers.walkers[iw].stack.ovlp[1], walkers.stack[iw].ovlp[1], decimal=10
+            )
 
         propagator.propagate_walkers(walkers, hamiltonian, trial, debug=True)
         legacy_walkers = legacy_propagate_walkers(
-                            legacy_hamiltonian, legacy_trial, legacy_walkers, 
-                            legacy_propagator, xi=propagator.xi)
+            legacy_hamiltonian, legacy_trial, legacy_walkers, legacy_propagator, xi=propagator.xi
+        )
 
 
 if __name__ == "__main__":

--- a/ipie/addons/thermal/qmc/calc.py
+++ b/ipie/addons/thermal/qmc/calc.py
@@ -18,18 +18,16 @@
 
 """Helper Routines for setting up a calculation"""
 
-from ipie.config import MPI
-from ipie.utils.mpi import MPIHandler
-from ipie.utils.io import get_input_value
-
-from ipie.systems.utils import get_system
-from ipie.hamiltonians.utils import get_hamiltonian
-
-from ipie.addons.thermal.trial.utils import get_trial_density_matrix
-from ipie.addons.thermal.walkers.uhf_walkers import UHFThermalWalkers
 from ipie.addons.thermal.propagation.propagator import Propagator
 from ipie.addons.thermal.qmc.options import ThermalQMCOpts, ThermalQMCParams
 from ipie.addons.thermal.qmc.thermal_afqmc import ThermalAFQMC
+from ipie.addons.thermal.trial.utils import get_trial_density_matrix
+from ipie.addons.thermal.walkers.uhf_walkers import UHFThermalWalkers
+from ipie.config import MPI
+from ipie.hamiltonians.utils import get_hamiltonian
+from ipie.systems.utils import get_system
+from ipie.utils.io import get_input_value
+from ipie.utils.mpi import MPIHandler
 
 
 def get_driver(options: dict, comm: MPI.COMM_WORLD) -> ThermalAFQMC:
@@ -56,7 +54,9 @@ def get_driver(options: dict, comm: MPI.COMM_WORLD) -> ThermalAFQMC:
 
     if comm.rank != 0:
         verbosity = 0
-    lowrank = get_input_value(wlk_opts, "lowrank", default=False, alias=["low_rank"], verbose=verbosity)
+    lowrank = get_input_value(
+        wlk_opts, "lowrank", default=False, alias=["low_rank"], verbose=verbosity
+    )
     batched = get_input_value(qmc_opts, "batched", default=False, verbose=verbosity)
     debug = get_input_value(qmc_opts, "debug", default=False, verbose=verbosity)
 
@@ -87,11 +87,19 @@ def get_driver(options: dict, comm: MPI.COMM_WORLD) -> ThermalAFQMC:
             comm=comm,
             verbose=verbosity,
         )
-        stack_size = get_input_value(wlk_opts, 'stack_size', default=10, verbose=verbosity)
-        lowrank_thresh = get_input_value(wlk_opts, 'lowrank_thresh', default=1e-6, alias=["low_rank_thresh"], verbose=verbosity)
+        stack_size = get_input_value(wlk_opts, "stack_size", default=10, verbose=verbosity)
+        lowrank_thresh = get_input_value(
+            wlk_opts, "lowrank_thresh", default=1e-6, alias=["low_rank_thresh"], verbose=verbosity
+        )
         walkers = UHFThermalWalkers(
-                    trial, hamiltonian.nbasis, qmc.nwalkers, stack_size=stack_size, 
-                    lowrank=lowrank, lowrank_thresh=lowrank_thresh, verbose=verbosity)
+            trial,
+            hamiltonian.nbasis,
+            qmc.nwalkers,
+            stack_size=stack_size,
+            lowrank=lowrank,
+            lowrank_thresh=lowrank_thresh,
+            verbose=verbosity,
+        )
 
         if (comm.rank == 0) and (qmc.nsteps > 1):
             print("Only num_steps_per_block = 1 allowed in thermal code! Resetting to value of 1.")
@@ -112,7 +120,6 @@ def get_driver(options: dict, comm: MPI.COMM_WORLD) -> ThermalAFQMC:
         propagator = Propagator[type(hamiltonian)](params.timestep, params.mu)
         propagator.build(hamiltonian, trial, walkers, mpi_handler)
         afqmc = ThermalAFQMC(
-            system,
             hamiltonian,
             trial,
             walkers,
@@ -136,7 +143,7 @@ def build_thermal_afqmc_driver(
 ):
     if comm.rank != 0:
         verbosity = 0
-    
+
     sys_opts = {"nup": nelec[0], "ndown": nelec[1]}
     ham_opts = {"integrals": hamiltonian_file}
     qmc_opts = {"rng_seed": seed}

--- a/ipie/addons/thermal/qmc/options.py
+++ b/ipie/addons/thermal/qmc/options.py
@@ -60,6 +60,7 @@ class ThermalQMCOpts(QMCOpts):
     beta : float
         Inverse temperature.
     """
+
     # pylint: disable=dangerous-default-value
     # TODO: Remove this class / replace with dataclass
     def __init__(self, inputs={}, verbose=False):
@@ -87,7 +88,7 @@ class ThermalQMCParams(QMCParams):
     ----------
     mu : float
         Chemical potential.
-    beta : float 
+    beta : float
         Inverse temperature.
     num_walkers : int
         Number of walkers **per** core / task / computational unit.
@@ -104,19 +105,19 @@ class ThermalQMCParams(QMCParams):
     pop_control_freq : int
         Frequency at which population control occurs.
     rng_seed : int
-        The random number seed. If run in parallel the seeds on other cores / 
+        The random number seed. If run in parallel the seeds on other cores /
         threads are determined from this.
     """
+
     # Due to structure of FT algorithm, `num_steps_per_block` is fixed at 1.
     # Overide whatever input for backward compatibility.
-    num_steps_per_block: ClassVar[int] = 1 
+    num_steps_per_block: ClassVar[int] = 1
     mu: Optional[float] = None
     beta: Optional[float] = None
-    pop_control_method: str = 'pair_branch'
-    
+    pop_control_method: str = "pair_branch"
+
     def __post_init__(self):
         if self.mu is None:
             raise TypeError("__init__ missing 1 required argument: 'mu'")
         if self.beta is None:
             raise TypeError("__init__ missing 1 required argument: 'beta'")
-

--- a/ipie/addons/thermal/qmc/tests/test_afqmc_generic.py
+++ b/ipie/addons/thermal/qmc/tests/test_afqmc_generic.py
@@ -18,26 +18,29 @@
 
 import json
 import tempfile
-import h5py
 import uuid
-import pytest
-import numpy
 from typing import Union
+
+import h5py
+import numpy
+import pytest
 
 try:
     from ipie.addons.thermal.utils.legacy_testing import build_legacy_driver_generic_test_instance
+
     _no_cython = False
 
 except ModuleNotFoundError:
     _no_cython = True
 
-from ipie.config import MPI
-from ipie.analysis.extraction import (
-        extract_test_data_hdf5, 
-        extract_data,
-        extract_observable, 
-        extract_mixed_estimates)
 from ipie.addons.thermal.utils.testing import build_driver_generic_test_instance
+from ipie.analysis.extraction import (
+    extract_data,
+    extract_mixed_estimates,
+    extract_observable,
+    extract_test_data_hdf5,
+)
+from ipie.config import MPI
 
 comm = MPI.COMM_WORLD
 serial_test = comm.size == 1
@@ -69,12 +72,12 @@ def test_thermal_afqmc():
     nblocks = 12
     stabilize_freq = 10
     pop_control_freq = 1
-    pop_control_method = 'pair_branch'
-    #pop_control_method = 'comb'
+    pop_control_method = "pair_branch"
+    # pop_control_method = 'comb'
     lowrank = False
 
     verbose = 0 if (comm.rank != 0) else 1
-     # Local energy evaluation in legacy code seems wrong.
+    # Local energy evaluation in legacy code seems wrong.
     complex_integrals = False
     debug = True
     seed = 7
@@ -85,15 +88,28 @@ def test_thermal_afqmc():
         # Test.
         # ---------------------------------------------------------------------
         afqmc = build_driver_generic_test_instance(
-                nelec, nbasis, mu, beta, timestep, nblocks, nwalkers=nwalkers, 
-                lowrank=lowrank, pop_control_method=pop_control_method, 
-                stabilize_freq=stabilize_freq, pop_control_freq=pop_control_freq,
-                complex_integrals=complex_integrals, debug=debug, seed=seed, 
-                verbose=verbose)
+            nelec,
+            nbasis,
+            mu,
+            beta,
+            timestep,
+            nblocks,
+            nwalkers=nwalkers,
+            lowrank=lowrank,
+            pop_control_method=pop_control_method,
+            stabilize_freq=stabilize_freq,
+            pop_control_freq=pop_control_freq,
+            complex_integrals=complex_integrals,
+            debug=debug,
+            seed=seed,
+            verbose=verbose,
+        )
         afqmc.run(verbose=verbose, estimator_filename=tmpf1.name)
         afqmc.finalise()
-        afqmc.estimators.compute_estimators(afqmc.hamiltonian, afqmc.trial, afqmc.walkers)
-        
+        afqmc.estimators.compute_estimators(
+            hamiltonian=afqmc.hamiltonian, trial=afqmc.trial, walker_batch=afqmc.walkers
+        )
+
         test_energy_data = None
         test_energy_numer = None
         test_energy_denom = None
@@ -104,17 +120,27 @@ def test_thermal_afqmc():
             test_energy_numer = afqmc.estimators["energy"]["ENumer"]
             test_energy_denom = afqmc.estimators["energy"]["EDenom"]
             test_number_data = extract_observable(afqmc.estimators.filename, "nav")
-        
+
         # ---------------------------------------------------------------------
         # Legacy.
         # ---------------------------------------------------------------------
         legacy_afqmc = build_legacy_driver_generic_test_instance(
-                        afqmc.hamiltonian, comm, nelec, mu, beta, timestep, 
-                        nblocks, nwalkers=nwalkers, lowrank=lowrank, 
-                        stabilize_freq=stabilize_freq,
-                        pop_control_freq=pop_control_freq,
-                        pop_control_method=pop_control_method, seed=seed, 
-                        estimator_filename=tmpf2.name, verbose=verbose)
+            afqmc.hamiltonian,
+            comm,
+            nelec,
+            mu,
+            beta,
+            timestep,
+            nblocks,
+            nwalkers=nwalkers,
+            lowrank=lowrank,
+            stabilize_freq=stabilize_freq,
+            pop_control_freq=pop_control_freq,
+            pop_control_method=pop_control_method,
+            seed=seed,
+            estimator_filename=tmpf2.name,
+            verbose=verbose,
+        )
         legacy_afqmc.run(comm=comm)
         legacy_afqmc.finalise(verbose=False)
         legacy_afqmc.estimators.estimators["mixed"].update(
@@ -124,7 +150,8 @@ def test_thermal_afqmc():
             legacy_afqmc.trial,
             legacy_afqmc.walk,
             0,
-            legacy_afqmc.propagators.free_projection)
+            legacy_afqmc.propagators.free_projection,
+        )
 
         legacy_mixed_data = None
         enum = None
@@ -136,33 +163,41 @@ def test_thermal_afqmc():
             enum = legacy_afqmc.estimators.estimators["mixed"].names
             legacy_energy_numer = legacy_afqmc.estimators.estimators["mixed"].estimates[enum.enumer]
             legacy_energy_denom = legacy_afqmc.estimators.estimators["mixed"].estimates[enum.edenom]
-        
+
             # Check.
             assert test_energy_numer.real == pytest.approx(legacy_energy_numer.real)
             assert test_energy_denom.real == pytest.approx(legacy_energy_denom.real)
             assert test_energy_numer.imag == pytest.approx(legacy_energy_numer.imag)
             assert test_energy_denom.imag == pytest.approx(legacy_energy_denom.imag)
-        
+
             assert numpy.mean(test_energy_data.WeightFactor.values[1:-1].real) == pytest.approx(
-                numpy.mean(legacy_mixed_data.WeightFactor.values[1:-1].real))
+                numpy.mean(legacy_mixed_data.WeightFactor.values[1:-1].real)
+            )
             assert numpy.mean(test_energy_data.Weight.values[1:-1].real) == pytest.approx(
-                numpy.mean(legacy_mixed_data.Weight.values[1:-1].real))
+                numpy.mean(legacy_mixed_data.Weight.values[1:-1].real)
+            )
             assert numpy.mean(test_energy_data.ENumer.values[:-1].real) == pytest.approx(
-                numpy.mean(legacy_mixed_data.ENumer.values[:-1].real))
+                numpy.mean(legacy_mixed_data.ENumer.values[:-1].real)
+            )
             assert numpy.mean(test_energy_data.EDenom.values[:-1].real) == pytest.approx(
-                numpy.mean(legacy_mixed_data.EDenom.values[:-1].real))
+                numpy.mean(legacy_mixed_data.EDenom.values[:-1].real)
+            )
             assert numpy.mean(test_energy_data.ETotal.values[:-1].real) == pytest.approx(
-                numpy.mean(legacy_mixed_data.ETotal.values[:-1].real))
+                numpy.mean(legacy_mixed_data.ETotal.values[:-1].real)
+            )
             assert numpy.mean(test_energy_data.E1Body.values[:-1].real) == pytest.approx(
-                numpy.mean(legacy_mixed_data.E1Body.values[:-1].real))
+                numpy.mean(legacy_mixed_data.E1Body.values[:-1].real)
+            )
             assert numpy.mean(test_energy_data.E2Body.values[:-1].real) == pytest.approx(
-                numpy.mean(legacy_mixed_data.E2Body.values[:-1].real))
+                numpy.mean(legacy_mixed_data.E2Body.values[:-1].real)
+            )
             assert numpy.mean(test_energy_data.HybridEnergy.values[:-1].real) == pytest.approx(
-                numpy.mean(legacy_mixed_data.EHybrid.values[:-1].real))
+                numpy.mean(legacy_mixed_data.EHybrid.values[:-1].real)
+            )
             assert numpy.mean(test_number_data.Nav.values[:-1].real) == pytest.approx(
-                numpy.mean(legacy_mixed_data.Nav.values[:-1].real))
-    
+                numpy.mean(legacy_mixed_data.Nav.values[:-1].real)
+            )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     test_thermal_afqmc()
-

--- a/ipie/addons/thermal/qmc/thermal_afqmc.py
+++ b/ipie/addons/thermal/qmc/thermal_afqmc.py
@@ -29,7 +29,6 @@ from ipie.addons.thermal.walkers.pop_controller import ThermalPopController
 from ipie.addons.thermal.walkers.uhf_walkers import UHFThermalWalkers
 from ipie.estimators.estimator_base import EstimatorBase
 from ipie.qmc.afqmc import AFQMCBase
-from ipie.systems.generic import Generic
 from ipie.utils.backend import arraylib as xp
 from ipie.utils.backend import synchronize
 from ipie.utils.io import to_json

--- a/ipie/addons/thermal/qmc/thermal_afqmc.py
+++ b/ipie/addons/thermal/qmc/thermal_afqmc.py
@@ -15,31 +15,29 @@
 # Authors: Fionn Malone <fmalone@google.com>
 #          Joonho Lee
 #
-
 """Driver to perform Thermal AFQMC calculation"""
-
-import numpy
-import time
 import json
+import time
 from typing import Dict, Optional, Tuple
 
+import numpy
+
+from ipie.addons.thermal.estimators.handler import ThermalEstimatorHandler
+from ipie.addons.thermal.propagation.propagator import Propagator
+from ipie.addons.thermal.qmc.options import ThermalQMCParams
 from ipie.addons.thermal.walkers.pop_controller import ThermalPopController
 from ipie.addons.thermal.walkers.uhf_walkers import UHFThermalWalkers
-from ipie.addons.thermal.propagation.propagator import Propagator
-from ipie.addons.thermal.estimators.handler import ThermalEstimatorHandler
-from ipie.addons.thermal.qmc.options import ThermalQMCParams
-
-from ipie.utils.io import to_json
+from ipie.estimators.estimator_base import EstimatorBase
+from ipie.qmc.afqmc import AFQMCBase
+from ipie.systems.generic import Generic
 from ipie.utils.backend import arraylib as xp
 from ipie.utils.backend import synchronize
+from ipie.utils.io import to_json
 from ipie.utils.mpi import MPIHandler
-from ipie.systems.generic import Generic
-from ipie.estimators.estimator_base import EstimatorBase
 from ipie.walkers.base_walkers import WalkerAccumulator
-from ipie.qmc.afqmc import AFQMC
 
 
-class ThermalAFQMC(AFQMC):
+class ThermalAFQMC(AFQMCBase):
     """Thermal AFQMC driver.
 
     Parameters
@@ -63,48 +61,52 @@ class ThermalAFQMC(AFQMC):
         Seed deduced from params.rng_seed which is generally different on each
             MPI process.
     """
-    def __init__(self, 
-                 system, # For compatibility with 0T AFQMC code.
-                 hamiltonian, 
-                 trial, 
-                 walkers, 
-                 propagator, 
-                 mpi_handler,
-                 params: ThermalQMCParams, 
-                 debug: bool = False,
-                 verbose: int = 0):
-        super().__init__(system, hamiltonian, trial, walkers, propagator, mpi_handler, params, verbose)
+
+    def __init__(
+        self,
+        hamiltonian,
+        trial,
+        walkers,
+        propagator,
+        mpi_handler,
+        params: ThermalQMCParams,
+        debug: bool = False,
+        verbose: int = 0,
+    ):
+        super().__init__(
+            None, hamiltonian, trial, walkers, propagator, mpi_handler, params, verbose
+        )
         self.debug = debug
 
         if self.debug and verbose:
-            print('# Using legacy `update_weights`.')
+            print("# Using legacy `update_weights`.")
 
-    
     @staticmethod
     def build(
-            nelec: Tuple[int, int],
-            mu: float,
-            beta: float,
-            hamiltonian,
-            trial,
-            nwalkers: int = 100,
-            stack_size: int = 10,
-            seed: int = None,
-            nblocks: int = 100,
-            timestep: float = 0.005,
-            stabilize_freq: int = 5,
-            pop_control_freq: int = 5,
-            pop_control_method: str = 'pair_branch',
-            lowrank: bool = False,
-            lowrank_thresh: float = 1e-6,
-            debug: bool = False,
-            verbose: int = 0,
-            mpi_handler=None,) -> "Thermal AFQMC":
+        nelec: Tuple[int, int],
+        mu: float,
+        beta: float,
+        hamiltonian,
+        trial,
+        nwalkers: int = 100,
+        stack_size: int = 10,
+        seed: Optional[int] = None,
+        nblocks: int = 100,
+        timestep: float = 0.005,
+        stabilize_freq: int = 5,
+        pop_control_freq: int = 5,
+        pop_control_method: str = "pair_branch",
+        lowrank: bool = False,
+        lowrank_thresh: float = 1e-6,
+        debug: bool = False,
+        verbose: int = 0,
+        mpi_handler=None,
+    ) -> "ThermalAFQMC":
         """Factory method to build thermal AFQMC driver from hamiltonian and trial density matrix.
 
         Parameters
         ----------
-        nelec : tuple(int, int)
+        num_elec : tuple(int, int)
             Number of alpha and beta electrons.
         mu : float
             Chemical potential.
@@ -140,47 +142,54 @@ class ThermalAFQMC(AFQMC):
 
         else:
             comm = mpi_handler.comm
-        
+
         # pylint: disable = no-value-for-parameter
         params = ThermalQMCParams(
-                    mu=mu,
-                    beta=beta,
-                    num_walkers=nwalkers,
-                    total_num_walkers=nwalkers * comm.size,
-                    num_blocks=nblocks,
-                    timestep=timestep,
-                    num_stblz=stabilize_freq,
-                    pop_control_freq=pop_control_freq,
-                    pop_control_method=pop_control_method,
-                    rng_seed=seed)
+            mu=mu,
+            beta=beta,
+            num_walkers=nwalkers,
+            total_num_walkers=nwalkers * comm.size,
+            num_blocks=nblocks,
+            timestep=timestep,
+            num_stblz=stabilize_freq,
+            pop_control_freq=pop_control_freq,
+            pop_control_method=pop_control_method,
+            rng_seed=seed,
+        )
 
-        system = Generic(nelec) 
         walkers = UHFThermalWalkers(
-                    trial, hamiltonian.nbasis, nwalkers, stack_size=stack_size,
-                    lowrank=lowrank, lowrank_thresh=lowrank_thresh, 
-                    mpi_handler=mpi_handler, verbose=verbose)
-        propagator = Propagator[type(hamiltonian)](
-                        timestep, mu, lowrank=lowrank, verbose=verbose)
-        propagator.build(hamiltonian, trial=trial, walkers=walkers, 
-                         mpi_handler=mpi_handler, verbose=verbose)
+            trial,
+            hamiltonian.nbasis,
+            nwalkers,
+            stack_size=stack_size,
+            lowrank=lowrank,
+            lowrank_thresh=lowrank_thresh,
+            mpi_handler=mpi_handler,
+            verbose=verbose,
+        )
+        propagator = Propagator[type(hamiltonian)](timestep, mu, lowrank=lowrank, verbose=verbose)
+        propagator.build(
+            hamiltonian, trial=trial, walkers=walkers, mpi_handler=mpi_handler, verbose=verbose
+        )
         return ThermalAFQMC(
-                system,
-                hamiltonian,
-                trial,
-                walkers,
-                propagator,
-                mpi_handler,
-                params,
-                debug=debug,
-                verbose=verbose)
+            hamiltonian,
+            trial,
+            walkers,
+            propagator,
+            mpi_handler,
+            params,
+            debug=debug,
+            verbose=verbose,
+        )
 
-
-    def run(self, 
-            walkers = None, 
-            verbose: bool = True,
-            estimator_filename = None,
-            additional_estimators: Optional[Dict[str, EstimatorBase]] = None,
-            print_time_slice: bool = False):
+    def run(
+        self,
+        walkers=None,
+        estimator_filename=None,
+        verbose: bool = True,
+        additional_estimators: Optional[Dict[str, EstimatorBase]] = None,
+        print_time_slice: bool = False,
+    ):
         """Perform Thermal AFQMC simulation on state object using open-ended random walk.
 
         Parameters
@@ -200,21 +209,22 @@ class ThermalAFQMC(AFQMC):
         # Setup.
         self.setup_timers()
         ft_setup = time.time()
-        eshift = 0.
+        eshift = 0.0
 
         if walkers is not None:
             self.walkers = walkers
 
         self.pcontrol = ThermalPopController(
-                            self.params.num_walkers,
-                            self.params.num_steps_per_block,
-                            self.mpi_handler,
-                            self.params.pop_control_method,
-                            verbose=self.verbose)
-        
+            self.params.num_walkers,
+            self.params.num_steps_per_block,
+            self.mpi_handler,
+            self.params.pop_control_method,
+            verbose=self.verbose,
+        )
+
         self.get_env_info()
         self.setup_estimators(estimator_filename, additional_estimators=additional_estimators)
-        
+
         synchronize()
         comm = self.mpi_handler.comm
         self.tsetup += time.time() - ft_setup
@@ -237,18 +247,20 @@ class ThermalAFQMC(AFQMC):
 
                 start = time.time()
                 self.propagator.propagate_walkers(
-                        self.walkers, self.hamiltonian, self.trial, eshift, debug=self.debug)
+                    self.walkers, self.hamiltonian, self.trial, eshift, debug=self.debug
+                )
 
                 self.tprop_fbias = self.propagator.timer.tfbias
                 self.tprop_update = self.propagator.timer.tupdate
                 self.tprop_vhs = self.propagator.timer.tvhs
                 self.tprop_gemm = self.propagator.timer.tgemm
-                
+
                 start_clip = time.time()
                 if t > 0:
                     wbound = self.pcontrol.total_weight * 0.10
-                    xp.clip(self.walkers.weight, a_min=-wbound, a_max=wbound,
-                            out=self.walkers.weight)  # In-place clipping.
+                    xp.clip(
+                        self.walkers.weight, a_min=-wbound, a_max=wbound, out=self.walkers.weight
+                    )  # In-place clipping.
 
                 synchronize()
                 self.tprop_clip += time.time() - start_clip
@@ -259,7 +271,7 @@ class ThermalAFQMC(AFQMC):
 
                 self.tprop_barrier += time.time() - start_barrier
                 self.tprop += time.time() - start
-                
+
                 if (t > 0) and (t % self.params.pop_control_freq == 0):
                     start = time.time()
                     self.pcontrol.pop_control(self.walkers, comm)
@@ -269,11 +281,12 @@ class ThermalAFQMC(AFQMC):
                     self.tpopc_recv = self.pcontrol.timer.recv_time
                     self.tpopc_comm = self.pcontrol.timer.communication_time
                     self.tpopc_non_comm = self.pcontrol.timer.non_communication_time
-                
+
                 # Print estimators at each time slice.
                 if print_time_slice:
                     self.estimators.compute_estimators(
-                            self.hamiltonian, self.trial, self.walkers)
+                        hamiltonian=self.hamiltonian, trial=self.trial, walker_batch=self.walkers
+                    )
                     self.estimators.print_time_slice(comm, t, self.accumulators)
 
             # Accumulate weight, hybrid energy etc. across block.
@@ -285,10 +298,12 @@ class ThermalAFQMC(AFQMC):
             start = time.time()
             if step % self.params.num_steps_per_block == 0:
                 self.estimators.compute_estimators(
-                        self.hamiltonian, self.trial, self.walkers)
+                    hamiltonian=self.hamiltonian, trial=self.trial, walker_batch=self.walkers
+                )
 
                 self.estimators.print_block(
-                    comm, step // self.params.num_steps_per_block, self.accumulators)
+                    comm, step // self.params.num_steps_per_block, self.accumulators
+                )
                 self.accumulators.zero()
 
             synchronize()
@@ -300,17 +315,17 @@ class ThermalAFQMC(AFQMC):
             else:
                 eshift += self.accumulators.eshift - eshift
 
-            self.walkers.reset(self.trial) # Reset stack, weights, phase.
+            self.walkers.reset(self.trial)  # Reset stack, weights, phase.
 
             synchronize()
             self.tstep += time.time() - start_step
 
     def setup_estimators(
-        self,
-        filename,
-        additional_estimators: Optional[Dict[str, EstimatorBase]] = None):
+        self, filename, additional_estimators: Optional[Dict[str, EstimatorBase]] = None
+    ):
         self.accumulators = WalkerAccumulator(
-            ["Weight", "WeightFactor", "HybridEnergy"], self.params.num_steps_per_block)
+            ["Weight", "WeightFactor", "HybridEnergy"], self.params.num_steps_per_block
+        )
         comm = self.mpi_handler.comm
         self.estimators = ThermalEstimatorHandler(
             self.mpi_handler.comm,
@@ -318,7 +333,8 @@ class ThermalAFQMC(AFQMC):
             self.trial,
             walker_state=self.accumulators,
             verbose=(comm.rank == 0 and self.verbose),
-            filename=filename)
+            filename=filename,
+        )
 
         if additional_estimators is not None:
             for k, v in additional_estimators.items():
@@ -331,9 +347,9 @@ class ThermalAFQMC(AFQMC):
         self.estimators.initialize(comm)
 
         # Calculate estimates for initial distribution of walkers.
-        self.estimators.compute_estimators(self.hamiltonian,
-                                           self.trial, self.walkers)
+        self.estimators.compute_estimators(
+            hamiltonian=self.hamiltonian, trial=self.trial, walker_batch=self.walkers
+        )
         self.accumulators.update(self.walkers)
         self.estimators.print_block(comm, 0, self.accumulators)
         self.accumulators.zero()
-

--- a/ipie/addons/thermal/trial/chem_pot.py
+++ b/ipie/addons/thermal/trial/chem_pot.py
@@ -23,10 +23,10 @@ from ipie.addons.thermal.estimators.thermal import one_rdm_stable
 from ipie.utils.io import format_fixed_width_floats, format_fixed_width_strings
 
 
-def find_chemical_potential(alt_convention, rho, beta, num_bins, target, 
-                            deps=1e-6, max_it=1000, verbose=False):
-    """Find the chemical potential to match <N>.
-    """
+def find_chemical_potential(
+    alt_convention, rho, beta, num_bins, target, deps=1e-6, max_it=1000, verbose=False
+):
+    """Find the chemical potential to match <N>."""
     # TODO: some sort of generic starting point independent of
     # system/temperature
     dmu1 = dmu2 = 1
@@ -83,5 +83,4 @@ def delta_nav(dm, nav):
 
 
 def compute_rho(rho, mu, beta, sign=1):
-    return numpy.einsum(
-            "ijk,k->ijk", rho, numpy.exp(sign * beta * mu * numpy.ones(rho.shape[-1])))
+    return numpy.einsum("ijk,k->ijk", rho, numpy.exp(sign * beta * mu * numpy.ones(rho.shape[-1])))

--- a/ipie/addons/thermal/trial/mean_field.py
+++ b/ipie/addons/thermal/trial/mean_field.py
@@ -20,19 +20,38 @@ import numpy
 import scipy.linalg
 
 from ipie.addons.thermal.estimators.generic import fock_generic
+from ipie.addons.thermal.estimators.greens_function import greens_function
 from ipie.addons.thermal.estimators.particle_number import particle_number
 from ipie.addons.thermal.estimators.thermal import one_rdm_stable
-from ipie.addons.thermal.estimators.greens_function import greens_function
 from ipie.addons.thermal.trial.chem_pot import compute_rho, find_chemical_potential
 from ipie.addons.thermal.trial.one_body import OneBody
 
+
 class MeanField(OneBody):
-    def __init__(self, hamiltonian, nelec, beta, dt, options=None, alt_convention=False, H1=None, verbose=False):
+    def __init__(
+        self,
+        hamiltonian,
+        nelec,
+        beta,
+        dt,
+        options=None,
+        alt_convention=False,
+        H1=None,
+        verbose=False,
+    ):
         if options is None:
             options = {}
 
-        super().__init__(hamiltonian, nelec, beta, dt, options=options, 
-                         alt_convention=alt_convention, H1=H1, verbose=verbose)
+        super().__init__(
+            hamiltonian,
+            nelec,
+            beta,
+            dt,
+            options=options,
+            alt_convention=alt_convention,
+            H1=H1,
+            verbose=verbose,
+        )
         if verbose:
             print("# Building THF density matrix.")
 
@@ -42,12 +61,16 @@ class MeanField(OneBody):
         self.find_mu = options.get("find_mu", True)
         self.P, HMF, self.mu = self.thermal_hartree_fock(hamiltonian, beta)
         muN = self.mu * numpy.eye(hamiltonian.nbasis, dtype=self.G.dtype)
-        self.dmat = numpy.array([scipy.linalg.expm(-dt * (HMF[0] - muN)),
-                                 scipy.linalg.expm(-dt * (HMF[1] - muN))])
-        self.dmat_inv = numpy.array([scipy.linalg.inv(self.dmat[0], check_finite=False),
-                                     scipy.linalg.inv(self.dmat[1], check_finite=False)])
-        self.G = numpy.array([greens_function(self.dmat[0]), 
-                              greens_function(self.dmat[1])])
+        self.dmat = numpy.array(
+            [scipy.linalg.expm(-dt * (HMF[0] - muN)), scipy.linalg.expm(-dt * (HMF[1] - muN))]
+        )
+        self.dmat_inv = numpy.array(
+            [
+                scipy.linalg.inv(self.dmat[0], check_finite=False),
+                scipy.linalg.inv(self.dmat[1], check_finite=False),
+            ]
+        )
+        self.G = numpy.array([greens_function(self.dmat[0]), greens_function(self.dmat[1])])
         self.nav = particle_number(self.P).real
 
     def thermal_hartree_fock(self, hamiltonian, beta):
@@ -63,12 +86,18 @@ class MeanField(OneBody):
                 print(f"\n# Macro iteration: {it}")
 
             HMF = self.scf(hamiltonian, beta, mu_old, P)
-            rho = numpy.array([scipy.linalg.expm(-dt * HMF[0]), 
-                               scipy.linalg.expm(-dt * HMF[1])])
+            rho = numpy.array([scipy.linalg.expm(-dt * HMF[0]), scipy.linalg.expm(-dt * HMF[1])])
             if self.find_mu:
                 mu = find_chemical_potential(
-                        self.alt_convention, rho, dt, self.nstack, self.nav, 
-                        deps=self.deps, max_it=self.max_it, verbose=self.verbose)
+                    self.alt_convention,
+                    rho,
+                    dt,
+                    self.nstack,
+                    self.nav,
+                    deps=self.deps,
+                    max_it=self.max_it,
+                    verbose=self.verbose,
+                )
 
             else:
                 mu = self.mu
@@ -92,17 +121,19 @@ class MeanField(OneBody):
         HMF = fock_generic(hamiltonian, P)
         dt = self.dtau
         muN = mu * numpy.eye(hamiltonian.nbasis, dtype=self.G.dtype)
-        rho = numpy.array([scipy.linalg.expm(-dt * (HMF[0] - muN)),
-                           scipy.linalg.expm(-dt * (HMF[1] - muN))])
+        rho = numpy.array(
+            [scipy.linalg.expm(-dt * (HMF[0] - muN)), scipy.linalg.expm(-dt * (HMF[1] - muN))]
+        )
         Pold = one_rdm_stable(rho, self.nstack)
 
         if self.verbose:
             print("# Running Thermal SCF.")
 
-        for it in range(self.max_scf_it):
+        for _ in range(self.max_scf_it):
             HMF = fock_generic(hamiltonian, Pold)
-            rho = numpy.array([scipy.linalg.expm(-dt * (HMF[0] - muN)),
-                               scipy.linalg.expm(-dt * (HMF[1] - muN))])
+            rho = numpy.array(
+                [scipy.linalg.expm(-dt * (HMF[0] - muN)), scipy.linalg.expm(-dt * (HMF[1] - muN))]
+            )
             Pnew = (1 - self.alpha) * one_rdm_stable(rho, self.nstack) + self.alpha * Pold
             change = numpy.linalg.norm(Pnew - Pold)
 

--- a/ipie/addons/thermal/trial/one_body.py
+++ b/ipie/addons/thermal/trial/one_body.py
@@ -27,8 +27,17 @@ from ipie.utils.misc import update_stack
 
 
 class OneBody:
-    def __init__(self, hamiltonian, nelec, beta, dt, options=None,
-                 alt_convention=False, H1=None, verbose=False):
+    def __init__(
+        self,
+        hamiltonian,
+        nelec,
+        beta,
+        dt,
+        options=None,
+        alt_convention=False,
+        H1=None,
+        verbose=False,
+    ):
         if options is None:
             options = {}
 
@@ -43,7 +52,7 @@ class OneBody:
 
             except AttributeError:
                 self.H1 = hamiltonian.h1e
-                
+
         else:
             self.H1 = H1
 
@@ -59,7 +68,7 @@ class OneBody:
 
         if verbose:
             print(f"# condition number of BT: {cond: 10e}")
-        
+
         self.nelec = nelec
         self.nav = options.get("nav", None)
 
@@ -89,8 +98,9 @@ class OneBody:
             self.stack_size = min(self.nslice, int(3.0 / numpy.log10(self.cond)))
 
             if verbose:
-                print("# Initial stack size, # of slices: {}, {}".format(
-                    self.stack_size, self.nslice))
+                print(
+                    "# Initial stack size, # of slices: {}, {}".format(self.stack_size, self.nslice)
+                )
 
         # Adjust stack size
         self.stack_size = update_stack(self.stack_size, self.nslice, verbose=verbose)
@@ -109,15 +119,30 @@ class OneBody:
         self.dtau = self.stack_size * dt
 
         if self.mu is None:
-            self.rho = numpy.array([scipy.linalg.expm(-self.dtau * (self.H1[0])),
-                                    scipy.linalg.expm(-self.dtau * (self.H1[1]))])
+            self.rho = numpy.array(
+                [
+                    scipy.linalg.expm(-self.dtau * (self.H1[0])),
+                    scipy.linalg.expm(-self.dtau * (self.H1[1])),
+                ]
+            )
             self.mu = find_chemical_potential(
-                        self.alt_convention, self.rho, self.dtau, self.nstack,
-                        self.nav, deps=self.deps, max_it=self.max_it, verbose=verbose)
-            
+                self.alt_convention,
+                self.rho,
+                self.dtau,
+                self.nstack,
+                self.nav,
+                deps=self.deps,
+                max_it=self.max_it,
+                verbose=verbose,
+            )
+
         else:
-            self.rho = numpy.array([scipy.linalg.expm(-self.dtau * (self.H1[0])),
-                                    scipy.linalg.expm(-self.dtau * (self.H1[1]))])
+            self.rho = numpy.array(
+                [
+                    scipy.linalg.expm(-self.dtau * (self.H1[0])),
+                    scipy.linalg.expm(-self.dtau * (self.H1[1])),
+                ]
+            )
 
         if self.verbose:
             print(f"# Chemical potential in trial density matrix: {self.mu: .10e}")
@@ -129,8 +154,12 @@ class OneBody:
             print(f"# Average particle number in trial density matrix: {self.nav}")
 
         self.dmat = compute_rho(self.dmat, self.mu, dt, sign=sign)
-        self.dmat_inv = numpy.array([scipy.linalg.inv(self.dmat[0], check_finite=False),
-                                     scipy.linalg.inv(self.dmat[1], check_finite=False)])
+        self.dmat_inv = numpy.array(
+            [
+                scipy.linalg.inv(self.dmat[0], check_finite=False),
+                scipy.linalg.inv(self.dmat[1], check_finite=False),
+            ]
+        )
 
         self.G = numpy.array([greens_function(self.dmat[0]), greens_function(self.dmat[1])])
         self.error = False

--- a/ipie/addons/thermal/trial/one_body.py
+++ b/ipie/addons/thermal/trial/one_body.py
@@ -19,9 +19,9 @@
 import numpy
 import scipy.linalg
 
+from ipie.addons.thermal.estimators.greens_function import greens_function
 from ipie.addons.thermal.estimators.particle_number import particle_number
 from ipie.addons.thermal.estimators.thermal import one_rdm_stable
-from ipie.addons.thermal.estimators.greens_function import greens_function
 from ipie.addons.thermal.trial.chem_pot import compute_rho, find_chemical_potential
 from ipie.utils.misc import update_stack
 
@@ -98,9 +98,7 @@ class OneBody:
             self.stack_size = min(self.nslice, int(3.0 / numpy.log10(self.cond)))
 
             if verbose:
-                print(
-                    "# Initial stack size, # of slices: {}, {}".format(self.stack_size, self.nslice)
-                )
+                print(f"# Initial stack size, # of slices: {self.stack_size}, {self.nslice}")
 
         # Adjust stack size
         self.stack_size = update_stack(self.stack_size, self.nslice, verbose=verbose)

--- a/ipie/addons/thermal/trial/tests/test_chem_pot.py
+++ b/ipie/addons/thermal/trial/tests/test_chem_pot.py
@@ -21,7 +21,9 @@ import scipy.linalg
 import pytest
 
 from ipie.addons.thermal.trial.chem_pot import find_chemical_potential
-from ipie.legacy.trial_density_matrices.chem_pot import find_chemical_potential as legacy_find_chemical_potential
+from ipie.legacy.trial_density_matrices.chem_pot import (
+    find_chemical_potential as legacy_find_chemical_potential,
+)
 
 
 @pytest.mark.unit
@@ -36,8 +38,7 @@ def test_find_chemical_potential():
 
     dtau = dt * stack_size
     h1e = numpy.random.random((nbsf, nbsf))
-    rho = numpy.array([scipy.linalg.expm(-dtau * h1e),
-                       scipy.linalg.expm(-dtau * h1e)])
+    rho = numpy.array([scipy.linalg.expm(-dtau * h1e), scipy.linalg.expm(-dtau * h1e)])
 
     mu = find_chemical_potential(alt_convention, rho, dt, nstack, nav)
     legacy_mu = legacy_find_chemical_potential(alt_convention, rho, dt, nstack, nav)
@@ -45,8 +46,5 @@ def test_find_chemical_potential():
     numpy.testing.assert_allclose(mu, legacy_mu)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_find_chemical_potential()
-    
-   
-

--- a/ipie/addons/thermal/trial/tests/test_mean_field.py
+++ b/ipie/addons/thermal/trial/tests/test_mean_field.py
@@ -21,6 +21,7 @@ import pytest
 
 try:
     from ipie.legacy.trial_density_matrices.mean_field import MeanField as LegacyMeanField
+
     _no_cython = False
 
 except ModuleNotFoundError:
@@ -41,42 +42,45 @@ def test_mean_field():
     nelec = (nup, ndown)
     nbasis = 10
 
-    mu = -10.
+    mu = -10.0
     beta = 0.1
     timestep = 0.01
-    
+
     alt_convention = False
     sparse = False
     complex_integrals = True
     verbose = True
 
     sym = 8
-    if complex_integrals: sym = 4
-    
+    if complex_integrals:
+        sym = 4
+
     # Test.
     system = Generic(nelec)
-    h1e, chol, _, eri = generate_hamiltonian(nbasis, nelec, cplx=complex_integrals, 
-                                             sym=sym, tol=1e-10)
-    hamiltonian = HamGeneric(h1e=numpy.array([h1e, h1e]),
-                             chol=chol.reshape((-1, nbasis**2)).T.copy(),
-                             ecore=0)
+    h1e, chol, _, eri = generate_hamiltonian(
+        nbasis, nelec, cplx=complex_integrals, sym=sym, tol=1e-10
+    )
+    hamiltonian = HamGeneric(
+        h1e=numpy.array([h1e, h1e]), chol=chol.reshape((-1, nbasis**2)).T.copy(), ecore=0
+    )
     trial = MeanField(hamiltonian, nelec, beta, timestep, verbose=verbose)
 
     # Lgeacy.
     legacy_system = Generic(nelec, verbose=verbose)
     legacy_system.mu = mu
     legacy_hamiltonian = LegacyHamGeneric(
-                            h1e=hamiltonian.H1,
-                            chol=hamiltonian.chol,
-                            ecore=hamiltonian.ecore, verbose=verbose)
+        h1e=hamiltonian.H1, chol=hamiltonian.chol, ecore=hamiltonian.ecore, verbose=verbose
+    )
     legacy_hamiltonian.hs_pot = numpy.copy(hamiltonian.chol)
     legacy_hamiltonian.hs_pot = legacy_hamiltonian.hs_pot.T.reshape(
-            (hamiltonian.nchol, hamiltonian.nbasis, hamiltonian.nbasis))
+        (hamiltonian.nchol, hamiltonian.nbasis, hamiltonian.nbasis)
+    )
     legacy_hamiltonian.mu = mu
     legacy_hamiltonian._alt_convention = alt_convention
     legacy_hamiltonian.sparse = sparse
-    legacy_trial = LegacyMeanField(legacy_system, legacy_hamiltonian, beta, 
-                                   timestep, verbose=verbose)
+    legacy_trial = LegacyMeanField(
+        legacy_system, legacy_hamiltonian, beta, timestep, verbose=verbose
+    )
 
     assert trial.nelec == nelec
     numpy.testing.assert_almost_equal(trial.nav, numpy.sum(nelec), decimal=5)
@@ -93,8 +97,5 @@ def test_mean_field():
     numpy.testing.assert_allclose(trial.dmat_inv, legacy_trial.dmat_inv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_mean_field()
-    
-   
-

--- a/ipie/addons/thermal/trial/tests/test_one_body.py
+++ b/ipie/addons/thermal/trial/tests/test_one_body.py
@@ -32,7 +32,7 @@ def test_one_body():
     nelec = (nup, ndown)
     nbasis = 10
 
-    mu = -1.
+    mu = -1.0
     beta = 0.1
     timestep = 0.01
 
@@ -40,15 +40,17 @@ def test_one_body():
     verbose = True
 
     sym = 8
-    if complex_integrals: sym = 4
-    
+    if complex_integrals:
+        sym = 4
+
     # Test.
     system = Generic(nelec)
-    h1e, chol, _, eri = generate_hamiltonian(nbasis, nelec, cplx=complex_integrals, 
-                                             sym=sym, tol=1e-10)
-    hamiltonian = HamGeneric(h1e=numpy.array([h1e, h1e]),
-                             chol=chol.reshape((-1, nbasis**2)).T.copy(),
-                             ecore=0)
+    h1e, chol, _, eri = generate_hamiltonian(
+        nbasis, nelec, cplx=complex_integrals, sym=sym, tol=1e-10
+    )
+    hamiltonian = HamGeneric(
+        h1e=numpy.array([h1e, h1e]), chol=chol.reshape((-1, nbasis**2)).T.copy(), ecore=0
+    )
     trial = OneBody(hamiltonian, nelec, beta, timestep, verbose=verbose)
 
     assert trial.nelec == nelec
@@ -59,8 +61,5 @@ def test_one_body():
     assert trial.G.shape == (2, nbasis, nbasis)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_one_body()
-    
-   
-

--- a/ipie/addons/thermal/trial/utils.py
+++ b/ipie/addons/thermal/trial/utils.py
@@ -20,8 +20,7 @@ from ipie.addons.thermal.trial.mean_field import MeanField
 from ipie.addons.thermal.trial.one_body import OneBody
 
 
-def get_trial_density_matrix(hamiltonian, nelec, beta, dt, options=None, 
-                             comm=None, verbose=False):
+def get_trial_density_matrix(hamiltonian, nelec, beta, dt, options=None, comm=None, verbose=False):
     """Wrapper to select trial wavefunction class.
 
     Parameters
@@ -50,12 +49,26 @@ def get_trial_density_matrix(hamiltonian, nelec, beta, dt, options=None,
             )
 
         elif trial_type == "one_body":
-            trial = OneBody(hamiltonian, nelec, beta, dt, options=options, 
-                            alt_convention=alt_convention, verbose=verbose)
+            trial = OneBody(
+                hamiltonian,
+                nelec,
+                beta,
+                dt,
+                options=options,
+                alt_convention=alt_convention,
+                verbose=verbose,
+            )
 
         elif trial_type == "thermal_hartree_fock":
-            trial = MeanField(hamiltonian, nelec, beta, dt, options=options, 
-                              alt_convention=alt_convention, verbose=verbose)
+            trial = MeanField(
+                hamiltonian,
+                nelec,
+                beta,
+                dt,
+                options=options,
+                alt_convention=alt_convention,
+                verbose=verbose,
+            )
 
         else:
             trial = None

--- a/ipie/addons/thermal/utils/legacy_testing.py
+++ b/ipie/addons/thermal/utils/legacy_testing.py
@@ -16,94 +16,92 @@
 #          Joonho Lee
 #
 
-import numpy
 from typing import Tuple, Union
 
+import numpy
+
+from ipie.addons.thermal.qmc.options import ThermalQMCOpts
+from ipie.legacy.hamiltonians._generic import Generic as LegacyHamGeneric
+from ipie.legacy.hamiltonians.ueg import UEG as LegacyHamUEG
+from ipie.legacy.qmc.thermal_afqmc import ThermalAFQMC as LegacyThermalAFQMC
+from ipie.legacy.systems.ueg import UEG as LegacyUEG
+from ipie.legacy.thermal_propagation.continuous import Continuous
+from ipie.legacy.thermal_propagation.planewave import PlaneWave
+from ipie.legacy.trial_density_matrices.mean_field import MeanField as LegacyMeanField
+from ipie.legacy.trial_density_matrices.onebody import OneBody as LegacyOneBody
+from ipie.legacy.walkers.handler import Walkers
 from ipie.systems.generic import Generic
 from ipie.utils.mpi import MPIHandler
 
-from ipie.addons.thermal.qmc.options import ThermalQMCOpts
 
-from ipie.legacy.systems.ueg import UEG as LegacyUEG
-from ipie.legacy.hamiltonians.ueg import UEG as LegacyHamUEG
-from ipie.legacy.hamiltonians._generic import Generic as LegacyHamGeneric
-from ipie.legacy.trial_density_matrices.onebody import OneBody as LegacyOneBody
-from ipie.legacy.trial_density_matrices.mean_field import MeanField as LegacyMeanField
-from ipie.legacy.walkers.handler import Walkers
-from ipie.legacy.thermal_propagation.continuous import Continuous
-from ipie.legacy.thermal_propagation.planewave import PlaneWave
-from ipie.legacy.qmc.thermal_afqmc import ThermalAFQMC as LegacyThermalAFQMC
-
-
-def legacy_propagate_walkers(legacy_hamiltonian, legacy_trial, legacy_walkers, legacy_propagator, xi=None):
+def legacy_propagate_walkers(
+    legacy_hamiltonian, legacy_trial, legacy_walkers, legacy_propagator, xi=None
+):
     if xi is None:
         xi = [None] * len(legacy_walkers)
 
     for iw, walker in enumerate(legacy_walkers.walkers):
-        legacy_propagator.propagate_walker(
-                legacy_hamiltonian, walker, legacy_trial, xi=xi[iw])
+        legacy_propagator.propagate_walker(legacy_hamiltonian, walker, legacy_trial, xi=xi[iw])
 
     return legacy_walkers
 
 
 def build_legacy_generic_test_case_handlers(
-        hamiltonian,
-        comm,
-        nelec: Tuple[int, int],
-        mu: float,
-        beta: float,
-        timestep: float,
-        nwalkers: int = 100,
-        stack_size: int = 10,
-        lowrank: bool = False,
-        lowrank_thresh: float = 1e-6,
-        stabilize_freq: int = 5,
-        pop_control_freq: int = 5,
-        pop_control_method: str = 'pair_branch',
-        alt_convention: bool = False,
-        sparse: bool = False,
-        mf_trial: bool = True,
-        propagate: bool = False,
-        seed: Union[int, None] = None,
-        verbose: int = 0):
+    hamiltonian,
+    comm,
+    nelec: Tuple[int, int],
+    mu: float,
+    beta: float,
+    timestep: float,
+    nwalkers: int = 100,
+    stack_size: int = 10,
+    lowrank: bool = False,
+    lowrank_thresh: float = 1e-6,
+    stabilize_freq: int = 5,
+    pop_control_freq: int = 5,
+    pop_control_method: str = "pair_branch",
+    alt_convention: bool = False,
+    sparse: bool = False,
+    mf_trial: bool = True,
+    propagate: bool = False,
+    seed: Union[int, None] = None,
+    verbose: int = 0,
+):
     numpy.random.seed(seed)
-    
+
     legacy_options = {
         "walkers": {
             "stack_size": stack_size,
             "low_rank": lowrank,
             "low_rank_thresh": lowrank_thresh,
-            "pop_control": pop_control_method
+            "pop_control": pop_control_method,
         },
-
-        "propagator": {
-            "optimised": False
-        },
+        "propagator": {"optimised": False},
     }
 
     # 1. Build system.
     legacy_system = Generic(nelec, verbose=verbose)
     legacy_system.mu = mu
-    
+
     # 2. Build Hamiltonian.
     legacy_hamiltonian = LegacyHamGeneric(
-                            h1e=hamiltonian.H1,
-                            chol=hamiltonian.chol,
-                            ecore=hamiltonian.ecore)
+        h1e=hamiltonian.H1, chol=hamiltonian.chol, ecore=hamiltonian.ecore
+    )
     legacy_hamiltonian.hs_pot = numpy.copy(hamiltonian.chol)
     legacy_hamiltonian.hs_pot = legacy_hamiltonian.hs_pot.T.reshape(
-            (hamiltonian.nchol, hamiltonian.nbasis, hamiltonian.nbasis))
+        (hamiltonian.nchol, hamiltonian.nbasis, hamiltonian.nbasis)
+    )
     legacy_hamiltonian.mu = mu
     legacy_hamiltonian._alt_convention = alt_convention
     legacy_hamiltonian.sparse = sparse
-    
+
     # 3. Build trial.
-    legacy_trial = LegacyOneBody(legacy_system, legacy_hamiltonian, beta, 
-                                 timestep, verbose=verbose)
+    legacy_trial = LegacyOneBody(legacy_system, legacy_hamiltonian, beta, timestep, verbose=verbose)
     if mf_trial:
-        legacy_trial = LegacyMeanField(legacy_system, legacy_hamiltonian, beta, 
-                                       timestep, verbose=verbose)
-    # 4. Build walkers.    
+        legacy_trial = LegacyMeanField(
+            legacy_system, legacy_hamiltonian, beta, timestep, verbose=verbose
+        )
+    # 4. Build walkers.
     qmc_opts = ThermalQMCOpts()
     qmc_opts.nwalkers = nwalkers
     qmc_opts.ntot_walkers = nwalkers
@@ -115,50 +113,63 @@ def build_legacy_generic_test_case_handlers(
     qmc_opts.pop_control_method = pop_control_method
     qmc_opts.seed = seed
 
-    legacy_walkers = Walkers(legacy_system, legacy_hamiltonian, legacy_trial,
-                             qmc_opts, walker_opts=legacy_options['walkers'],
-                             verbose=verbose, comm=comm)
+    legacy_walkers = Walkers(
+        legacy_system,
+        legacy_hamiltonian,
+        legacy_trial,
+        qmc_opts,
+        walker_opts=legacy_options["walkers"],
+        verbose=verbose,
+        comm=comm,
+    )
 
     # 5. Build propagator.
     legacy_propagator = Continuous(
-                            legacy_options["propagator"], qmc_opts, legacy_system, 
-                            legacy_hamiltonian, legacy_trial, verbose=verbose, 
-                            lowrank=lowrank)
+        legacy_options["propagator"],
+        qmc_opts,
+        legacy_system,
+        legacy_hamiltonian,
+        legacy_trial,
+        verbose=verbose,
+        lowrank=lowrank,
+    )
 
     if propagate:
-        for t in range(legacy_walkers[0].stack.ntime_slices):
-            for iw, walker in enumerate(legacy_walkers):
-                legacy_propagator.propagate_walker(
-                        legacy_hamiltonian, walker, legacy_trial)
+        for _ in range(legacy_walkers[0].stack.ntime_slices):
+            for _, walker in enumerate(legacy_walkers):
+                legacy_propagator.propagate_walker(legacy_hamiltonian, walker, legacy_trial)
 
-    legacy_objs = {'system': legacy_system,
-                   'trial': legacy_trial,
-                   'hamiltonian': legacy_hamiltonian,
-                   'walkers': legacy_walkers,
-                   'propagator': legacy_propagator}
+    legacy_objs = {
+        "system": legacy_system,
+        "trial": legacy_trial,
+        "hamiltonian": legacy_hamiltonian,
+        "walkers": legacy_walkers,
+        "propagator": legacy_propagator,
+    }
     return legacy_objs
-    
+
 
 def build_legacy_generic_test_case_handlers_mpi(
-        hamiltonian,
-        mpi_handler: MPIHandler,
-        nelec: Tuple[int, int],
-        mu: float,
-        beta: float,
-        timestep: float,
-        nwalkers: int = 100,
-        stack_size: int = 10,
-        lowrank: bool = False,
-        lowrank_thresh: float = 1e-6,
-        stabilize_freq: int = 5,
-        pop_control_freq: int = 5,
-        pop_control_method: str = 'pair_branch',
-        alt_convention: bool = False,
-        sparse: bool = False,
-        mf_trial: bool = True,
-        propagate: bool = False,
-        seed: Union[int, None] = None,
-        verbose: int = 0):
+    hamiltonian,
+    mpi_handler: MPIHandler,
+    nelec: Tuple[int, int],
+    mu: float,
+    beta: float,
+    timestep: float,
+    nwalkers: int = 100,
+    stack_size: int = 10,
+    lowrank: bool = False,
+    lowrank_thresh: float = 1e-6,
+    stabilize_freq: int = 5,
+    pop_control_freq: int = 5,
+    pop_control_method: str = "pair_branch",
+    alt_convention: bool = False,
+    sparse: bool = False,
+    mf_trial: bool = True,
+    propagate: bool = False,
+    seed: Union[int, None] = None,
+    verbose: int = 0,
+):
     numpy.random.seed(seed)
     comm = mpi_handler.comm
 
@@ -167,37 +178,34 @@ def build_legacy_generic_test_case_handlers_mpi(
             "stack_size": stack_size,
             "low_rank": lowrank,
             "low_rank_thresh": lowrank_thresh,
-            "pop_control": pop_control_method
+            "pop_control": pop_control_method,
         },
-
-        "propagator": {
-            "optimised": False
-        },
+        "propagator": {"optimised": False},
     }
-    
+
     # 1. Build system.
     legacy_system = Generic(nelec, verbose=verbose)
     legacy_system.mu = mu
-    
+
     # 2. Build Hamiltonian.
     legacy_hamiltonian = LegacyHamGeneric(
-                            h1e=hamiltonian.H1,
-                            chol=hamiltonian.chol,
-                            ecore=hamiltonian.ecore)
+        h1e=hamiltonian.H1, chol=hamiltonian.chol, ecore=hamiltonian.ecore
+    )
     legacy_hamiltonian.hs_pot = numpy.copy(hamiltonian.chol)
     legacy_hamiltonian.hs_pot = legacy_hamiltonian.hs_pot.T.reshape(
-            (hamiltonian.nchol, hamiltonian.nbasis, hamiltonian.nbasis))
+        (hamiltonian.nchol, hamiltonian.nbasis, hamiltonian.nbasis)
+    )
     legacy_hamiltonian.mu = mu
     legacy_hamiltonian._alt_convention = alt_convention
     legacy_hamiltonian.sparse = sparse
-    
+
     # 3. Build trial.
-    legacy_trial = LegacyOneBody(legacy_system, legacy_hamiltonian, beta, 
-                                 timestep, verbose=verbose)
+    legacy_trial = LegacyOneBody(legacy_system, legacy_hamiltonian, beta, timestep, verbose=verbose)
     if mf_trial:
-        legacy_trial = LegacyMeanField(legacy_system, legacy_hamiltonian, beta, 
-                                       timestep, verbose=verbose)
-    # 4. Build walkers.    
+        legacy_trial = LegacyMeanField(
+            legacy_system, legacy_hamiltonian, beta, timestep, verbose=verbose
+        )
+    # 4. Build walkers.
     qmc_opts = ThermalQMCOpts()
     qmc_opts.nwalkers = nwalkers
     qmc_opts.ntot_walkers = nwalkers * comm.size
@@ -209,53 +217,66 @@ def build_legacy_generic_test_case_handlers_mpi(
     qmc_opts.pop_control_method = pop_control_method
     qmc_opts.seed = seed
 
-    legacy_walkers = Walkers(legacy_system, legacy_hamiltonian, legacy_trial,
-                             qmc_opts, walker_opts=legacy_options['walkers'],
-                             verbose=verbose, comm=comm)
+    legacy_walkers = Walkers(
+        legacy_system,
+        legacy_hamiltonian,
+        legacy_trial,
+        qmc_opts,
+        walker_opts=legacy_options["walkers"],
+        verbose=verbose,
+        comm=comm,
+    )
 
     # 5. Build propagator.
     legacy_propagator = Continuous(
-                            legacy_options["propagator"], qmc_opts, legacy_system, 
-                            legacy_hamiltonian, legacy_trial, verbose=verbose, 
-                            lowrank=lowrank)
+        legacy_options["propagator"],
+        qmc_opts,
+        legacy_system,
+        legacy_hamiltonian,
+        legacy_trial,
+        verbose=verbose,
+        lowrank=lowrank,
+    )
 
     if propagate:
-        for t in range(legacy_walkers[0].stack.ntime_slices):
-            for iw, walker in enumerate(legacy_walkers):
-                legacy_propagator.propagate_walker(
-                        legacy_hamiltonian, walker, legacy_trial)
+        for _ in range(legacy_walkers[0].stack.ntime_slices):
+            for _, walker in enumerate(legacy_walkers):
+                legacy_propagator.propagate_walker(legacy_hamiltonian, walker, legacy_trial)
 
-    legacy_objs = {'system': legacy_system,
-                   'trial': legacy_trial,
-                   'hamiltonian': legacy_hamiltonian,
-                   'walkers': legacy_walkers,
-                   'propagator': legacy_propagator}
+    legacy_objs = {
+        "system": legacy_system,
+        "trial": legacy_trial,
+        "hamiltonian": legacy_hamiltonian,
+        "walkers": legacy_walkers,
+        "propagator": legacy_propagator,
+    }
     return legacy_objs
-    
+
 
 def build_legacy_driver_generic_test_instance(
-        hamiltonian,
-        comm,
-        nelec: Tuple[int, int],
-        mu: float,
-        beta: float,
-        timestep: float,
-        nblocks: int,
-        nwalkers: int = 100,
-        stack_size: int = 10,
-        lowrank: bool = False,
-        lowrank_thresh: float = 1e-6,
-        stabilize_freq: int = 5,
-        pop_control_freq: int = 5,
-        pop_control_method: str = 'pair_branch',
-        alt_convention: bool = False,
-        sparse: bool = False,
-        seed: Union[int, None] = None,
-        estimator_filename: Union[str, None] = None,
-        verbose: int = 0):
+    hamiltonian,
+    comm,
+    nelec: Tuple[int, int],
+    mu: float,
+    beta: float,
+    timestep: float,
+    nblocks: int,
+    nwalkers: int = 100,
+    stack_size: int = 10,
+    lowrank: bool = False,
+    lowrank_thresh: float = 1e-6,
+    stabilize_freq: int = 5,
+    pop_control_freq: int = 5,
+    pop_control_method: str = "pair_branch",
+    alt_convention: bool = False,
+    sparse: bool = False,
+    seed: Union[int, None] = None,
+    estimator_filename: Union[str, None] = None,
+    verbose: int = 0,
+):
     nup, ndown = nelec
     numpy.random.seed(seed)
-    
+
     legacy_options = {
         "qmc": {
             "dt": timestep,
@@ -269,27 +290,16 @@ def build_legacy_driver_generic_test_instance(
             "pop_control_freq": pop_control_freq,
             "pop_control_method": pop_control_method,
             "rng_seed": seed,
-            "batched": False
+            "batched": False,
         },
-
-        "propagator": {
-            "optimised": False
-        },
-
+        "propagator": {"optimised": False},
         "walkers": {
             "stack_size": stack_size,
             "low_rank": lowrank,
             "low_rank_thresh": lowrank_thresh,
-            "pop_control": pop_control_method
+            "pop_control": pop_control_method,
         },
-
-        "system": {
-            "name": "Generic",
-            "nup": nup,
-            "ndown": ndown,
-            "mu": mu
-        },
-
+        "system": {"name": "Generic", "nup": nup, "ndown": ndown, "mu": mu},
         "estimators": {
             "filename": estimator_filename,
         },
@@ -298,42 +308,44 @@ def build_legacy_driver_generic_test_instance(
     legacy_system = Generic(nelec)
     legacy_system.mu = mu
     legacy_hamiltonian = LegacyHamGeneric(
-                            h1e=hamiltonian.H1,
-                            chol=hamiltonian.chol,
-                            ecore=hamiltonian.ecore)
+        h1e=hamiltonian.H1, chol=hamiltonian.chol, ecore=hamiltonian.ecore
+    )
     legacy_hamiltonian.hs_pot = numpy.copy(hamiltonian.chol)
     legacy_hamiltonian.hs_pot = legacy_hamiltonian.hs_pot.T.reshape(
-            (hamiltonian.nchol, hamiltonian.nbasis, hamiltonian.nbasis))
+        (hamiltonian.nchol, hamiltonian.nbasis, hamiltonian.nbasis)
+    )
     legacy_hamiltonian.mu = mu
     legacy_hamiltonian._alt_convention = alt_convention
     legacy_hamiltonian.sparse = sparse
     legacy_trial = LegacyMeanField(legacy_system, legacy_hamiltonian, beta, timestep)
-    
-    afqmc = LegacyThermalAFQMC(comm, legacy_options, legacy_system, 
-                               legacy_hamiltonian, legacy_trial, verbose=verbose)
+
+    afqmc = LegacyThermalAFQMC(
+        comm, legacy_options, legacy_system, legacy_hamiltonian, legacy_trial, verbose=verbose
+    )
     return afqmc
 
 
 def build_legacy_ueg_test_case_handlers(
-        comm,
-        nelec: Tuple[int, int],
-        rs: float,
-        ecut: float,
-        mu: float,
-        beta: float,
-        timestep: float,
-        nwalkers: int = 100,
-        stack_size: int = 10,
-        lowrank: bool = False,
-        lowrank_thresh: float = 1e-6,
-        propagate: bool = False,
-        stabilize_freq: int = 5,
-        pop_control_freq: int = 5,
-        pop_control_method: str = 'pair_branch',
-        alt_convention: bool = False,
-        sparse: bool = False,
-        seed: Union[int, None] = None,
-        verbose: int = 0):
+    comm,
+    nelec: Tuple[int, int],
+    rs: float,
+    ecut: float,
+    mu: float,
+    beta: float,
+    timestep: float,
+    nwalkers: int = 100,
+    stack_size: int = 10,
+    lowrank: bool = False,
+    lowrank_thresh: float = 1e-6,
+    propagate: bool = False,
+    stabilize_freq: int = 5,
+    pop_control_freq: int = 5,
+    pop_control_method: str = "pair_branch",
+    alt_convention: bool = False,
+    sparse: bool = False,
+    seed: Union[int, None] = None,
+    verbose: int = 0,
+):
     numpy.random.seed(seed)
     nup, ndown = nelec
     legacy_options = {
@@ -344,35 +356,30 @@ def build_legacy_ueg_test_case_handlers(
             "ecut": ecut,
             "thermal": True,
             "write_integrals": False,
-            "low_rank": lowrank
+            "low_rank": lowrank,
         },
-
-        "propagator": {
-            "optimised": False
-        },
-
+        "propagator": {"optimised": False},
         "walkers": {
             "stack_size": stack_size,
             "low_rank": lowrank,
             "low_rank_thresh": lowrank_thresh,
-            "pop_control": pop_control_method
+            "pop_control": pop_control_method,
         },
     }
 
     # 1. Build out system.
-    legacy_system = LegacyUEG(options=legacy_options['ueg'])
+    legacy_system = LegacyUEG(options=legacy_options["ueg"])
     legacy_system.mu = mu
-    
+
     # 2. Build Hamiltonian.
-    legacy_hamiltonian = LegacyHamUEG(legacy_system, options=legacy_options['ueg'])
+    legacy_hamiltonian = LegacyHamUEG(legacy_system, options=legacy_options["ueg"])
     legacy_hamiltonian.mu = mu
     legacy_hamiltonian._alt_convention = alt_convention
 
     # 3. Build trial.
-    legacy_trial = LegacyOneBody(legacy_system, legacy_hamiltonian, beta, 
-                                 timestep, verbose=verbose)
-    
-    # 4. Build walkers.    
+    legacy_trial = LegacyOneBody(legacy_system, legacy_hamiltonian, beta, timestep, verbose=verbose)
+
+    # 4. Build walkers.
     qmc_opts = ThermalQMCOpts()
     qmc_opts.nwalkers = nwalkers
     qmc_opts.ntot_walkers = nwalkers * comm.size
@@ -384,50 +391,64 @@ def build_legacy_ueg_test_case_handlers(
     qmc_opts.pop_control_method = pop_control_method
     qmc_opts.seed = seed
 
-    legacy_walkers = Walkers(legacy_system, legacy_hamiltonian, legacy_trial,
-                             qmc_opts, walker_opts=legacy_options['walkers'],
-                             verbose=verbose, comm=comm)
+    legacy_walkers = Walkers(
+        legacy_system,
+        legacy_hamiltonian,
+        legacy_trial,
+        qmc_opts,
+        walker_opts=legacy_options["walkers"],
+        verbose=verbose,
+        comm=comm,
+    )
 
     # 5. Build propagator.
-    legacy_propagator = PlaneWave(legacy_system, legacy_hamiltonian, legacy_trial, 
-                                  qmc_opts, options=legacy_options["propagator"], 
-                                  lowrank=lowrank, verbose=verbose)
+    legacy_propagator = PlaneWave(
+        legacy_system,
+        legacy_hamiltonian,
+        legacy_trial,
+        qmc_opts,
+        options=legacy_options["propagator"],
+        lowrank=lowrank,
+        verbose=verbose,
+    )
 
     if propagate:
-        for t in range(legacy_walkers[0].stack.ntime_slices):
-            for iw, walker in enumerate(legacy_walkers):
-                legacy_propagator.propagate_walker(
-                        legacy_hamiltonian, walker, legacy_trial)
+        for _ in range(legacy_walkers[0].stack.ntime_slices):
+            for _, walker in enumerate(legacy_walkers):
+                legacy_propagator.propagate_walker(legacy_hamiltonian, walker, legacy_trial)
 
-    legacy_objs = {'system': legacy_system,
-                   'trial': legacy_trial,
-                   'hamiltonian': legacy_hamiltonian,
-                   'walkers': legacy_walkers,
-                   'propagator': legacy_propagator}
+    legacy_objs = {
+        "system": legacy_system,
+        "trial": legacy_trial,
+        "hamiltonian": legacy_hamiltonian,
+        "walkers": legacy_walkers,
+        "propagator": legacy_propagator,
+    }
     return legacy_objs
-    
+
 
 def build_legacy_driver_ueg_test_instance(
-        comm,
-        nelec: Tuple[int, int],
-        rs: float,
-        ecut: float,
-        mu: float,
-        beta: float,
-        timestep: float,
-        nblocks: int,
-        nwalkers: int = 100,
-        stack_size: int = 10,
-        lowrank: bool = False,
-        lowrank_thresh: float = 1e-6,
-        stabilize_freq: int = 5,
-        pop_control_freq: int = 5,
-        pop_control_method: str = 'pair_branch',
-        alt_convention: bool = False,
-        sparse: bool = False,
-        seed: Union[int, None] = None,
-        estimator_filename: Union[str, None] = None,
-        verbose: int = 0):
+    comm,
+    nelec: Tuple[int, int],
+    rs: float,
+    ecut: float,
+    mu: float,
+    beta: float,
+    timestep: float,
+    nblocks: int,
+    nwalkers: int = 100,
+    stack_size: int = 10,
+    lowrank: bool = False,
+    lowrank_thresh: float = 1e-6,
+    stabilize_freq: int = 5,
+    pop_control_freq: int = 5,
+    pop_control_method: str = "pair_branch",
+    alt_convention: bool = False,
+    sparse: bool = False,
+    seed: Union[int, None] = None,
+    estimator_filename: Union[str, None] = None,
+    verbose: int = 0,
+):
     numpy.random.seed(seed)
     nup, ndown = nelec
     legacy_options = {
@@ -438,9 +459,8 @@ def build_legacy_driver_ueg_test_instance(
             "ecut": ecut,
             "thermal": True,
             "write_integrals": False,
-            "low_rank": lowrank
+            "low_rank": lowrank,
         },
-
         "qmc": {
             "dt": timestep,
             # Input of `nwalkers` refers to the total number of walkers in
@@ -453,40 +473,34 @@ def build_legacy_driver_ueg_test_instance(
             "pop_control_freq": pop_control_freq,
             "pop_control_method": pop_control_method,
             "rng_seed": seed,
-            "batched": False
+            "batched": False,
         },
-
-        "propagator": {
-            "optimised": False
-        },
-
+        "propagator": {"optimised": False},
         "walkers": {
             "stack_size": stack_size,
             "low_rank": lowrank,
             "low_rank_thresh": lowrank_thresh,
-            "pop_control": pop_control_method
+            "pop_control": pop_control_method,
         },
-        
         "estimators": {
             "filename": estimator_filename,
         },
     }
 
     # 1. Build out system.
-    legacy_system = LegacyUEG(options=legacy_options['ueg'])
+    legacy_system = LegacyUEG(options=legacy_options["ueg"])
     legacy_system.mu = mu
-    
+
     # 2. Build Hamiltonian.
-    legacy_hamiltonian = LegacyHamUEG(legacy_system, options=legacy_options['ueg'])
+    legacy_hamiltonian = LegacyHamUEG(legacy_system, options=legacy_options["ueg"])
     legacy_hamiltonian.mu = mu
     legacy_hamiltonian._alt_convention = alt_convention
 
     # 3. Build trial.
-    legacy_trial = LegacyOneBody(legacy_system, legacy_hamiltonian, beta, 
-                                 timestep, verbose=verbose)
-    
-    # 4. Build Thermal AFQMC.
-    afqmc = LegacyThermalAFQMC(comm, legacy_options, legacy_system, 
-                               legacy_hamiltonian, legacy_trial, verbose=verbose)
-    return afqmc
+    legacy_trial = LegacyOneBody(legacy_system, legacy_hamiltonian, beta, timestep, verbose=verbose)
 
+    # 4. Build Thermal AFQMC.
+    afqmc = LegacyThermalAFQMC(
+        comm, legacy_options, legacy_system, legacy_hamiltonian, legacy_trial, verbose=verbose
+    )
+    return afqmc

--- a/ipie/addons/thermal/utils/testing.py
+++ b/ipie/addons/thermal/utils/testing.py
@@ -16,55 +16,58 @@
 #          Joonho Lee
 #
 
-import numpy
 from typing import Tuple, Union
 
-from ipie.utils.mpi import MPIHandler
-from ipie.utils.testing import generate_hamiltonian
-from ipie.hamiltonians.generic import Generic as HamGeneric
+import numpy
 
-from ipie.addons.thermal.utils.ueg import UEG
-from ipie.addons.thermal.trial.one_body import OneBody
-from ipie.addons.thermal.trial.mean_field import MeanField
-from ipie.addons.thermal.walkers.uhf_walkers import UHFThermalWalkers
 from ipie.addons.thermal.propagation.phaseless_generic import PhaselessGeneric
 from ipie.addons.thermal.qmc.thermal_afqmc import ThermalAFQMC
+from ipie.addons.thermal.trial.mean_field import MeanField
+from ipie.addons.thermal.trial.one_body import OneBody
+from ipie.addons.thermal.utils.ueg import UEG
+from ipie.addons.thermal.walkers.uhf_walkers import UHFThermalWalkers
+from ipie.hamiltonians.generic import Generic as HamGeneric
+from ipie.utils.mpi import MPIHandler
+from ipie.utils.testing import generate_hamiltonian
 
 
 def build_generic_test_case_handlers(
-        nelec: Tuple[int, int],
-        nbasis: int,
-        mu: float,
-        beta: float,
-        timestep: float,
-        nwalkers: int = 100,
-        stack_size: int = 10,
-        lowrank: bool = False,
-        lowrank_thresh: float = 1e-6,
-        diagonal: bool = False,
-        mf_trial: bool = True,
-        propagate: bool = False,
-        complex_integrals: bool = False,
-        debug: bool = False,
-        with_eri: bool = False,
-        seed: Union[int, None] = None,
-        verbose: int = 0):
+    nelec: Tuple[int, int],
+    nbasis: int,
+    mu: float,
+    beta: float,
+    timestep: float,
+    nwalkers: int = 100,
+    stack_size: int = 10,
+    lowrank: bool = False,
+    lowrank_thresh: float = 1e-6,
+    diagonal: bool = False,
+    mf_trial: bool = True,
+    propagate: bool = False,
+    complex_integrals: bool = False,
+    debug: bool = False,
+    with_eri: bool = False,
+    seed: Union[int, None] = None,
+    verbose: int = 0,
+):
     sym = 8
-    if complex_integrals: sym = 4
+    if complex_integrals:
+        sym = 4
     numpy.random.seed(seed)
-    
+
     # 1. Generate random integrals.
-    h1e, chol, _, eri = generate_hamiltonian(nbasis, nelec, cplx=complex_integrals, 
-                                             sym=sym, tol=1e-10)
+    h1e, chol, _, eri = generate_hamiltonian(
+        nbasis, nelec, cplx=complex_integrals, sym=sym, tol=1e-10
+    )
 
     if diagonal:
         h1e = numpy.diag(numpy.diag(h1e))
-    
+
     # 2. Build Hamiltonian.
-    hamiltonian = HamGeneric(h1e=numpy.array([h1e, h1e]),
-                             chol=chol.reshape((-1, nbasis**2)).T.copy(),
-                             ecore=0)
-    
+    hamiltonian = HamGeneric(
+        h1e=numpy.array([h1e, h1e]), chol=chol.reshape((-1, nbasis**2)).T.copy(), ecore=0
+    )
+
     # 3. Build trial.
     trial = OneBody(hamiltonian, nelec, beta, timestep, verbose=verbose)
 
@@ -73,62 +76,73 @@ def build_generic_test_case_handlers(
 
     # 4. Build walkers.
     walkers = UHFThermalWalkers(
-                trial, nbasis, nwalkers, stack_size=stack_size, lowrank=lowrank, 
-                lowrank_thresh=lowrank_thresh, verbose=verbose)
-    
+        trial,
+        nbasis,
+        nwalkers,
+        stack_size=stack_size,
+        lowrank=lowrank,
+        lowrank_thresh=lowrank_thresh,
+        verbose=verbose,
+    )
+
     # 5. Build propagator.
     propagator = PhaselessGeneric(timestep, mu, lowrank=lowrank, verbose=verbose)
     propagator.build(hamiltonian, trial=trial, walkers=walkers, verbose=verbose)
 
     if propagate:
-        for t in range(walkers.stack[0].nslice):
+        for _ in range(walkers.stack[0].nslice):
             propagator.propagate_walkers(walkers, hamiltonian, trial, debug=debug)
 
-    objs = {'trial': trial,
-            'hamiltonian': hamiltonian,
-            'walkers': walkers,
-            'propagator': propagator}
+    objs = {
+        "trial": trial,
+        "hamiltonian": hamiltonian,
+        "walkers": walkers,
+        "propagator": propagator,
+    }
 
     if with_eri:
-        objs['eri'] = eri
+        objs["eri"] = eri
 
     return objs
 
 
 def build_generic_test_case_handlers_mpi(
-        nelec: Tuple[int, int],
-        nbasis: int,
-        mu: float,
-        beta: float,
-        timestep: float,
-        mpi_handler: MPIHandler,
-        nwalkers: int = 100,
-        stack_size: int = 10,
-        lowrank: bool = False,
-        lowrank_thresh: float = 1e-6,
-        diagonal: bool = False,
-        mf_trial: bool = True,
-        propagate: bool = False,
-        complex_integrals: bool = False,
-        debug: bool = False,
-        seed: Union[int, None] = None,
-        verbose: int = 0):
+    nelec: Tuple[int, int],
+    nbasis: int,
+    mu: float,
+    beta: float,
+    timestep: float,
+    mpi_handler: MPIHandler,
+    nwalkers: int = 100,
+    stack_size: int = 10,
+    lowrank: bool = False,
+    lowrank_thresh: float = 1e-6,
+    diagonal: bool = False,
+    mf_trial: bool = True,
+    propagate: bool = False,
+    complex_integrals: bool = False,
+    debug: bool = False,
+    seed: Union[int, None] = None,
+    verbose: int = 0,
+):
     sym = 8
-    if complex_integrals: sym = 4
+    if complex_integrals:
+        sym = 4
     numpy.random.seed(seed)
-    
+
     # 1. Generate random integrals.
-    h1e, chol, _, _ = generate_hamiltonian(nbasis, nelec, cplx=complex_integrals, 
-                                           sym=sym, tol=1e-10)
+    h1e, chol, _, _ = generate_hamiltonian(
+        nbasis, nelec, cplx=complex_integrals, sym=sym, tol=1e-10
+    )
 
     if diagonal:
         h1e = numpy.diag(numpy.diag(h1e))
-    
+
     # 2. Build Hamiltonian.
-    hamiltonian = HamGeneric(h1e=numpy.array([h1e, h1e]),
-                             chol=chol.reshape((-1, nbasis**2)).T.copy(),
-                             ecore=0)
-    
+    hamiltonian = HamGeneric(
+        h1e=numpy.array([h1e, h1e]), chol=chol.reshape((-1, nbasis**2)).T.copy(), ecore=0
+    )
+
     # 3. Build trial.
     trial = OneBody(hamiltonian, nelec, beta, timestep, verbose=verbose)
 
@@ -137,98 +151,125 @@ def build_generic_test_case_handlers_mpi(
 
     # 4. Build walkers.
     walkers = UHFThermalWalkers(
-                trial, nbasis, nwalkers, stack_size=stack_size, lowrank=lowrank, 
-                lowrank_thresh=lowrank_thresh, mpi_handler=mpi_handler, verbose=verbose)
-    
+        trial,
+        nbasis,
+        nwalkers,
+        stack_size=stack_size,
+        lowrank=lowrank,
+        lowrank_thresh=lowrank_thresh,
+        mpi_handler=mpi_handler,
+        verbose=verbose,
+    )
+
     # 5. Build propagator.
     propagator = PhaselessGeneric(timestep, mu, lowrank=lowrank, verbose=verbose)
-    propagator.build(hamiltonian, trial=trial, walkers=walkers, 
-                     mpi_handler=mpi_handler, verbose=verbose)
+    propagator.build(
+        hamiltonian, trial=trial, walkers=walkers, mpi_handler=mpi_handler, verbose=verbose
+    )
 
     if propagate:
-        for t in range(walkers.stack[0].nslice):
+        for _ in range(walkers.stack[0].nslice):
             propagator.propagate_walkers(walkers, hamiltonian, trial, debug=debug)
 
-    objs = {'trial': trial,
-            'hamiltonian': hamiltonian,
-            'walkers': walkers,
-            'propagator': propagator}
+    objs = {
+        "trial": trial,
+        "hamiltonian": hamiltonian,
+        "walkers": walkers,
+        "propagator": propagator,
+    }
     return objs
 
 
 def build_driver_generic_test_instance(
-        nelec: Tuple[int, int],
-        nbasis: int,
-        mu: float,
-        beta: float,
-        timestep: float,
-        nblocks: int,
-        nwalkers: int = 100,
-        stack_size: int = 10,
-        lowrank: bool = False,
-        lowrank_thresh: float = 1e-6,
-        stabilize_freq: int = 5,
-        pop_control_freq: int = 5,
-        pop_control_method: str = 'pair_branch',
-        diagonal: bool = False,
-        complex_integrals: bool = False,
-        debug: bool = False,
-        seed: Union[int, None] = None,
-        verbose: int = 0):
+    nelec: Tuple[int, int],
+    nbasis: int,
+    mu: float,
+    beta: float,
+    timestep: float,
+    nblocks: int,
+    nwalkers: int = 100,
+    stack_size: int = 10,
+    lowrank: bool = False,
+    lowrank_thresh: float = 1e-6,
+    stabilize_freq: int = 5,
+    pop_control_freq: int = 5,
+    pop_control_method: str = "pair_branch",
+    diagonal: bool = False,
+    complex_integrals: bool = False,
+    debug: bool = False,
+    seed: Union[int, None] = None,
+    verbose: int = 0,
+):
     sym = 8
-    if complex_integrals: sym = 4
+    if complex_integrals:
+        sym = 4
     numpy.random.seed(seed)
 
     # 1. Generate random integrals.
-    h1e, chol, _, _ = generate_hamiltonian(nbasis, nelec, cplx=complex_integrals, 
-                                           sym=sym, tol=1e-10)
-    
+    h1e, chol, _, _ = generate_hamiltonian(
+        nbasis, nelec, cplx=complex_integrals, sym=sym, tol=1e-10
+    )
+
     if diagonal:
         h1e = numpy.diag(numpy.diag(h1e))
-    
+
     # 2. Build Hamiltonian.
-    hamiltonian = HamGeneric(h1e=numpy.array([h1e, h1e]),
-                             chol=chol.reshape((-1, nbasis**2)).T.copy(),
-                             ecore=0)
-    
+    hamiltonian = HamGeneric(
+        h1e=numpy.array([h1e, h1e]), chol=chol.reshape((-1, nbasis**2)).T.copy(), ecore=0
+    )
+
     # 3. Build trial.
     trial = MeanField(hamiltonian, nelec, beta, timestep)
 
     # 4. Build Thermal AFQMC driver.
     afqmc = ThermalAFQMC.build(
-                nelec, mu, beta, hamiltonian, trial, nwalkers=nwalkers, 
-                stack_size=stack_size, seed=seed, nblocks=nblocks, timestep=timestep, 
-                stabilize_freq=stabilize_freq, pop_control_freq=pop_control_freq,
-                pop_control_method=pop_control_method, lowrank=lowrank, 
-                lowrank_thresh=lowrank_thresh, debug=debug, verbose=verbose)
+        nelec,
+        mu,
+        beta,
+        hamiltonian,
+        trial,
+        nwalkers=nwalkers,
+        stack_size=stack_size,
+        seed=seed,
+        nblocks=nblocks,
+        timestep=timestep,
+        stabilize_freq=stabilize_freq,
+        pop_control_freq=pop_control_freq,
+        pop_control_method=pop_control_method,
+        lowrank=lowrank,
+        lowrank_thresh=lowrank_thresh,
+        debug=debug,
+        verbose=verbose,
+    )
     return afqmc
 
 
 def build_ueg_test_case_handlers(
-        nelec: Tuple[int, int],
-        rs: float,
-        ecut: float,
-        mu: float,
-        beta: float,
-        timestep: float,
-        nwalkers: int = 100,
-        stack_size: int = 10,
-        lowrank: bool = False,
-        lowrank_thresh: float = 1e-6,
-        propagate: bool = False,
-        debug: bool = False,
-        seed: Union[int, None] = None,
-        verbose: int = 0):
+    nelec: Tuple[int, int],
+    rs: float,
+    ecut: float,
+    mu: float,
+    beta: float,
+    timestep: float,
+    nwalkers: int = 100,
+    stack_size: int = 10,
+    lowrank: bool = False,
+    lowrank_thresh: float = 1e-6,
+    propagate: bool = False,
+    debug: bool = False,
+    seed: Union[int, None] = None,
+    verbose: int = 0,
+):
     nup, ndown = nelec
     ueg_opts = {
-                "nup": nup,
-                "ndown": ndown,
-                "rs": rs,
-                "ecut": ecut,
-                "thermal": True,
-                "write_integrals": False,
-                "low_rank": lowrank
-                }
+        "nup": nup,
+        "ndown": ndown,
+        "rs": rs,
+        "ecut": ecut,
+        "thermal": True,
+        "write_integrals": False,
+        "low_rank": lowrank,
+    }
 
     numpy.random.seed(seed)
 
@@ -243,69 +284,79 @@ def build_ueg_test_case_handlers(
         print(f"# nchol = {nchol}")
         print(f"# nup = {nup}")
         print(f"# ndown = {ndown}")
-        
+
     h1 = ueg.H1[0]
-    chol = 2. * ueg.chol_vecs.toarray().copy()
-    ecore = 0.
+    chol = 2.0 * ueg.chol_vecs.toarray().copy()
+    ecore = 0.0
 
     # 2. Build Hamiltonian.
     hamiltonian = HamGeneric(
-            numpy.array([h1, h1], dtype=numpy.complex128), 
-            numpy.array(chol, dtype=numpy.complex128), 
-            ecore,
-            verbose=verbose)
+        numpy.array([h1, h1], dtype=numpy.complex128),
+        numpy.array(chol, dtype=numpy.complex128),
+        ecore,
+        verbose=verbose,
+    )
 
     # 3. Build trial.
     trial = OneBody(hamiltonian, nelec, beta, timestep, verbose=verbose)
 
     # 4. Build walkers.
     walkers = UHFThermalWalkers(
-                trial, nbasis, nwalkers, stack_size=stack_size, lowrank=lowrank, 
-                lowrank_thresh=lowrank_thresh, verbose=verbose)
-    
+        trial,
+        nbasis,
+        nwalkers,
+        stack_size=stack_size,
+        lowrank=lowrank,
+        lowrank_thresh=lowrank_thresh,
+        verbose=verbose,
+    )
+
     # 5. Build propagator.
     propagator = PhaselessGeneric(timestep, mu, lowrank=lowrank, verbose=verbose)
     propagator.build(hamiltonian, trial=trial, walkers=walkers, verbose=verbose)
 
     if propagate:
-        for t in range(walkers.stack[0].nslice):
+        for _ in range(walkers.stack[0].nslice):
             propagator.propagate_walkers(walkers, hamiltonian, trial, debug=debug)
 
-    objs = {'trial': trial,
-            'hamiltonian': hamiltonian,
-            'walkers': walkers,
-            'propagator': propagator}
+    objs = {
+        "trial": trial,
+        "hamiltonian": hamiltonian,
+        "walkers": walkers,
+        "propagator": propagator,
+    }
     return objs
 
 
 def build_driver_ueg_test_instance(
-        nelec: Tuple[int, int],
-        rs: float,
-        ecut: float,
-        mu: float,
-        beta: float,
-        timestep: float,
-        nblocks: int,
-        nwalkers: int = 100,
-        stack_size: int = 10,
-        lowrank: bool = False,
-        lowrank_thresh: float = 1e-6,
-        stabilize_freq: int = 5,
-        pop_control_freq: int = 5,
-        pop_control_method: str = 'pair_branch',
-        debug: bool = False,
-        seed: Union[int, None] = None,
-        verbose: int = 0):
+    nelec: Tuple[int, int],
+    rs: float,
+    ecut: float,
+    mu: float,
+    beta: float,
+    timestep: float,
+    nblocks: int,
+    nwalkers: int = 100,
+    stack_size: int = 10,
+    lowrank: bool = False,
+    lowrank_thresh: float = 1e-6,
+    stabilize_freq: int = 5,
+    pop_control_freq: int = 5,
+    pop_control_method: str = "pair_branch",
+    debug: bool = False,
+    seed: Union[int, None] = None,
+    verbose: int = 0,
+):
     nup, ndown = nelec
     ueg_opts = {
-                "nup": nup,
-                "ndown": ndown,
-                "rs": rs,
-                "ecut": ecut,
-                "thermal": True,
-                "write_integrals": False,
-                "low_rank": lowrank
-                }
+        "nup": nup,
+        "ndown": ndown,
+        "rs": rs,
+        "ecut": ecut,
+        "thermal": True,
+        "write_integrals": False,
+        "low_rank": lowrank,
+    }
 
     numpy.random.seed(seed)
 
@@ -320,27 +371,40 @@ def build_driver_ueg_test_instance(
         print(f"# nchol = {nchol}")
         print(f"# nup = {nup}")
         print(f"# ndown = {ndown}")
-        
+
     h1 = ueg.H1[0]
-    chol = 2. * ueg.chol_vecs.toarray().copy()
-    ecore = 0.
+    chol = 2.0 * ueg.chol_vecs.toarray().copy()
+    ecore = 0.0
 
     # 2. Build Hamiltonian.
     hamiltonian = HamGeneric(
-            numpy.array([h1, h1], dtype=numpy.complex128), 
-            numpy.array(chol, dtype=numpy.complex128), 
-            ecore,
-            verbose=verbose)
+        numpy.array([h1, h1], dtype=numpy.complex128),
+        numpy.array(chol, dtype=numpy.complex128),
+        ecore,
+        verbose=verbose,
+    )
 
     # 3. Build trial.
     trial = OneBody(hamiltonian, nelec, beta, timestep, verbose=verbose)
 
     # 4. Build Thermal AFQMC driver.
     afqmc = ThermalAFQMC.build(
-                nelec, mu, beta, hamiltonian, trial, nwalkers=nwalkers,
-                stack_size=stack_size, seed=seed, nblocks=nblocks, timestep=timestep, 
-                stabilize_freq=stabilize_freq, pop_control_freq=pop_control_freq,
-                pop_control_method=pop_control_method, lowrank=lowrank, 
-                lowrank_thresh=lowrank_thresh, debug=debug, verbose=verbose)
+        nelec,
+        mu,
+        beta,
+        hamiltonian,
+        trial,
+        nwalkers=nwalkers,
+        stack_size=stack_size,
+        seed=seed,
+        nblocks=nblocks,
+        timestep=timestep,
+        stabilize_freq=stabilize_freq,
+        pop_control_freq=pop_control_freq,
+        pop_control_method=pop_control_method,
+        lowrank=lowrank,
+        lowrank_thresh=lowrank_thresh,
+        debug=debug,
+        verbose=verbose,
+    )
     return afqmc
-

--- a/ipie/addons/thermal/walkers/pop_controller.py
+++ b/ipie/addons/thermal/walkers/pop_controller.py
@@ -36,8 +36,15 @@ class ThermalPopController(PopController):
         verbose=False,
     ):
         super().__init__(
-                num_walkers_local, num_steps, mpi_handler, pop_control_method,
-                min_weight, max_weight, reconfiguration_freq, verbose)
+            num_walkers_local,
+            num_steps,
+            mpi_handler,
+            pop_control_method,
+            min_weight,
+            max_weight,
+            reconfiguration_freq,
+            verbose,
+        )
 
     def pop_control(self, walkers, comm):
         self.timer.start_time()
@@ -102,7 +109,9 @@ def get_buffer(walkers, iw):
     buff = xp.zeros(walkers.buff_size, dtype=numpy.complex128)
     for d in walkers.buff_names:
         data = walkers.__dict__[d]
-        if (data is None) or isinstance(data, (int, float, complex, numpy.float64, numpy.complex128)):
+        if (data is None) or isinstance(
+            data, (int, float, complex, numpy.float64, numpy.complex128)
+        ):
             continue
         assert data.size % walkers.nwalkers == 0  # Only walker-specific data is being communicated
         if isinstance(data[iw], (xp.ndarray)):
@@ -135,18 +144,22 @@ def set_buffer(walkers, iw, buff):
     s = 0
     for d in walkers.buff_names:
         data = walkers.__dict__[d]
-        if (data is None) or isinstance(data, (int, float, complex, numpy.float64, numpy.complex128)):
+        if (data is None) or isinstance(
+            data, (int, float, complex, numpy.float64, numpy.complex128)
+        ):
             continue
         assert data.size % walkers.nwalkers == 0  # Only walker-specific data is being communicated
         if isinstance(data[iw], xp.ndarray):
             walkers.__dict__[d][iw] = xp.array(
-                buff[s : s + data[iw].size].reshape(data[iw].shape).copy())
+                buff[s : s + data[iw].size].reshape(data[iw].shape).copy()
+            )
             s += data[iw].size
         elif isinstance(data[iw], list):
             for ix, l in enumerate(data[iw]):
                 if isinstance(l, (xp.ndarray)):
                     walkers.__dict__[d][iw][ix] = xp.array(
-                        buff[s : s + l.size].reshape(l.shape).copy())
+                        buff[s : s + l.size].reshape(l.shape).copy()
+                    )
                     s += l.size
                 elif isinstance(l, (int, float, complex)):
                     walkers.__dict__[d][iw][ix] = buff[s]
@@ -159,8 +172,8 @@ def set_buffer(walkers, iw, buff):
             else:
                 walkers.__dict__[d][iw] = buff[s]
             s += 1
-        
-    walkers.stack[iw].set_buffer(buff[walkers.buff_size:])
+
+    walkers.stack[iw].set_buffer(buff[walkers.buff_size :])
 
 
 def comb(walkers, comm, weights, target_weight, timer=PopControllerTimer()):
@@ -286,11 +299,11 @@ def pair_branch(walkers, comm, max_weight, min_weight, timer=PopControllerTimer(
         glob_inf_1 = numpy.empty([comm.size, walkers.nwalkers], dtype=numpy.int64)
         glob_inf_1.fill(1)
         glob_inf_2 = numpy.array(
-            [[r for i in range(walkers.nwalkers)] for r in range(comm.size)],
-            dtype=numpy.int64)
+            [[r for i in range(walkers.nwalkers)] for r in range(comm.size)], dtype=numpy.int64
+        )
         glob_inf_3 = numpy.array(
-            [[r for i in range(walkers.nwalkers)] for r in range(comm.size)],
-            dtype=numpy.int64)
+            [[r for i in range(walkers.nwalkers)] for r in range(comm.size)], dtype=numpy.int64
+        )
 
     timer.add_non_communication()
 
@@ -308,9 +321,15 @@ def pair_branch(walkers, comm, max_weight, min_weight, timer=PopControllerTimer(
         # Rescale weights.
         glob_inf = numpy.zeros((walkers.nwalkers * comm.size, 4), dtype=numpy.float64)
         glob_inf[:, 0] = glob_inf_0.ravel()  # contains walker |w_i|
-        glob_inf[:, 1] = glob_inf_1.ravel()  # all initialized to 1 when it becomes 2 then it will be "branched"
-        glob_inf[:, 2] = glob_inf_2.ravel()  # contain processor+walker indices (initial) (i.e., where walkers live)
-        glob_inf[:, 3] = glob_inf_3.ravel()  # contain processor+walker indices (final) (i.e., where walkers live)
+        glob_inf[:, 1] = (
+            glob_inf_1.ravel()
+        )  # all initialized to 1 when it becomes 2 then it will be "branched"
+        glob_inf[:, 2] = (
+            glob_inf_2.ravel()
+        )  # contain processor+walker indices (initial) (i.e., where walkers live)
+        glob_inf[:, 3] = (
+            glob_inf_3.ravel()
+        )  # contain processor+walker indices (final) (i.e., where walkers live)
         sort = numpy.argsort(glob_inf[:, 0], kind="mergesort")
         isort = numpy.argsort(sort, kind="mergesort")
         glob_inf = glob_inf[sort]

--- a/ipie/addons/thermal/walkers/stack.py
+++ b/ipie/addons/thermal/walkers/stack.py
@@ -24,6 +24,7 @@ import scipy.linalg
 
 from ipie.utils.misc import get_numeric_names
 
+
 class PropagatorStack:
     def __init__(
         self,
@@ -67,8 +68,9 @@ class PropagatorStack:
         self.left = numpy.zeros((self.nstack, 2, nbasis, nbasis), dtype=dtype)
         self.right = numpy.zeros((self.nstack, 2, nbasis, nbasis), dtype=dtype)
 
-        self.G = numpy.asarray([numpy.eye(self.nbasis, dtype=dtype),  # Ga
-                                numpy.eye(self.nbasis, dtype=dtype)]) # Gb
+        self.G = numpy.asarray(
+            [numpy.eye(self.nbasis, dtype=dtype), numpy.eye(self.nbasis, dtype=dtype)]  # Ga
+        )  # Gb
 
         if self.lowrank:
             self.update_new = self.update_low_rank
@@ -329,8 +331,9 @@ class PropagatorStack:
                 self.theta[s][:, :] = 0.0
                 self.theta[s][:mT, :] = Qlcr_pad[:, :mT].dot(numpy.diag(Dlcr[:mT])).T
                 # self.G[s] = numpy.eye(self.nbasis, dtype=B[s].dtype) - self.CT[s][:,:mT].dot(self.theta[s][:mT,:])
-                self.G[s] = numpy.eye(self.nbasis, dtype=B[s].dtype) -\
-                            self.theta[s][:mT, :].T.dot(self.CT[s][:, :mT].T.conj())
+                self.G[s] = numpy.eye(self.nbasis, dtype=B[s].dtype) - self.theta[s][:mT, :].T.dot(
+                    self.CT[s][:, :mT].T.conj()
+                )
                 # self.CT[s][:,:mT] = self.CT[s][:,:mT].conj()
 
                 # print("# mL, mR, mT = {}, {}, {}".format(mL, mR, mT))
@@ -397,8 +400,9 @@ class PropagatorStack:
                 self.theta[s][:, :] = 0.0
                 self.theta[s][:mT, :] = Qlcr_pad[:, :mT].dot(numpy.diag(Dlcr[:mT])).T
                 # self.G[s] = numpy.eye(self.nbasis, dtype=B[s].dtype) - self.CT[s][:,:mT].dot(self.theta[s][:mT,:])
-                self.G[s] = numpy.eye(self.nbasis, dtype=B[s].dtype) -\
-                            self.theta[s][:mT, :].T.dot(self.CT[s][:, :mT].T.conj())
+                self.G[s] = numpy.eye(self.nbasis, dtype=B[s].dtype) - self.theta[s][:mT, :].T.dot(
+                    self.CT[s][:, :mT].T.conj()
+                )
 
             # self.CT = numpy.zeros(shape=(2, nbasis, nbasis),dtype=dtype)
             # self.theta = numpy.zeros(shape=(2, nbasis, nbasis),dtype=dtype)

--- a/ipie/addons/thermal/walkers/tests/__init__.py
+++ b/ipie/addons/thermal/walkers/tests/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/ipie/addons/thermal/walkers/tests/test_population_control.py
+++ b/ipie/addons/thermal/walkers/tests/test_population_control.py
@@ -23,6 +23,7 @@ from typing import Union
 try:
     from ipie.addons.thermal.utils.legacy_testing import build_legacy_generic_test_case_handlers_mpi
     from ipie.addons.thermal.utils.legacy_testing import legacy_propagate_walkers
+
     _no_cython = False
 
 except ModuleNotFoundError:
@@ -34,6 +35,7 @@ from ipie.addons.thermal.walkers.pop_controller import ThermalPopController
 from ipie.addons.thermal.utils.testing import build_generic_test_case_handlers_mpi
 
 comm = MPI.COMM_WORLD
+
 
 @pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
 @pytest.mark.unit
@@ -47,14 +49,14 @@ def test_pair_branch_batch():
     nbasis = 10
 
     # Thermal AFQMC params.
-    mu = -10.
+    mu = -10.0
     beta = 0.1
     timestep = 0.01
     nwalkers = 12
     nblocks = 3
     # Must be fixed at 1 for Thermal AFQMC--legacy code overides whatever input!
     nsteps_per_block = 1
-    pop_control_method = 'pair_branch'
+    pop_control_method = "pair_branch"
     lowrank = False
 
     mf_trial = True
@@ -65,51 +67,79 @@ def test_pair_branch_batch():
     numpy.random.seed(seed)
 
     # Test.
-    objs =  build_generic_test_case_handlers_mpi(
-            nelec, nbasis, mu, beta, timestep, mpi_handler, nwalkers=nwalkers, 
-            lowrank=lowrank, mf_trial=mf_trial, complex_integrals=complex_integrals, 
-            debug=debug, seed=seed, verbose=verbose)
-    trial = objs['trial']
-    hamiltonian = objs['hamiltonian']
-    walkers = objs['walkers']
-    propagator = objs['propagator']
-    pcontrol = ThermalPopController(nwalkers, nsteps_per_block, mpi_handler, 
-                                    pop_control_method, verbose=verbose)
-    
+    objs = build_generic_test_case_handlers_mpi(
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        mpi_handler,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    hamiltonian = objs["hamiltonian"]
+    walkers = objs["walkers"]
+    propagator = objs["propagator"]
+    pcontrol = ThermalPopController(
+        nwalkers, nsteps_per_block, mpi_handler, pop_control_method, verbose=verbose
+    )
+
     # Legacy.
     legacy_objs = build_legacy_generic_test_case_handlers_mpi(
-                    hamiltonian, mpi_handler, nelec, mu, beta, timestep, 
-                    nwalkers=nwalkers, lowrank=lowrank, mf_trial=mf_trial,
-                    seed=seed, verbose=verbose)
-    legacy_system = legacy_objs['system']
-    legacy_trial = legacy_objs['trial']
-    legacy_hamiltonian = legacy_objs['hamiltonian']
-    legacy_walkers = legacy_objs['walkers']
-    legacy_propagator = legacy_objs['propagator']
-    
-    for block in range(nblocks): 
+        hamiltonian,
+        mpi_handler,
+        nelec,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_system = legacy_objs["system"]
+    legacy_trial = legacy_objs["trial"]
+    legacy_hamiltonian = legacy_objs["hamiltonian"]
+    legacy_walkers = legacy_objs["walkers"]
+    legacy_propagator = legacy_objs["propagator"]
+
+    for block in range(nblocks):
         for t in range(walkers.stack[0].nslice):
             propagator.propagate_walkers(walkers, hamiltonian, trial, debug=True)
             legacy_walkers = legacy_propagate_walkers(
-                                legacy_hamiltonian, legacy_trial, legacy_walkers, 
-                                legacy_propagator, xi=propagator.xi)
-            
+                legacy_hamiltonian,
+                legacy_trial,
+                legacy_walkers,
+                legacy_propagator,
+                xi=propagator.xi,
+            )
+
             if t > 0:
                 pcontrol.pop_control(walkers, mpi_handler.comm)
                 legacy_walkers.pop_control(mpi_handler.comm)
 
-        walkers.reset(trial) # Reset stack, weights, phase.
+        walkers.reset(trial)  # Reset stack, weights, phase.
         legacy_walkers.reset(legacy_trial)
 
     for iw in range(walkers.nwalkers):
         assert numpy.allclose(walkers.Ga[iw], legacy_walkers.walkers[iw].G[0])
         assert numpy.allclose(walkers.Gb[iw], legacy_walkers.walkers[iw].G[1])
         assert numpy.allclose(walkers.weight[iw], legacy_walkers.walkers[iw].weight)
-        assert numpy.allclose(walkers.unscaled_weight[iw], legacy_walkers.walkers[iw].unscaled_weight)
+        assert numpy.allclose(
+            walkers.unscaled_weight[iw], legacy_walkers.walkers[iw].unscaled_weight
+        )
+
 
 # TODO: Lowrank code is WIP. See: https://github.com/JoonhoLee-Group/ipie/issues/302
-#@pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
-#@pytest.mark.unit
+# @pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
+# @pytest.mark.unit
 def test_pair_branch_batch_lowrank():
     mpi_handler = MPIHandler()
 
@@ -120,14 +150,14 @@ def test_pair_branch_batch_lowrank():
     nbasis = 10
 
     # Thermal AFQMC params.
-    mu = -10.
+    mu = -10.0
     beta = 0.1
     timestep = 0.01
     nwalkers = 12
     nblocks = 3
     # Must be fixed at 1 for Thermal AFQMC--legacy code overides whatever input!
     nsteps_per_block = 1
-    pop_control_method = 'pair_branch'
+    pop_control_method = "pair_branch"
     lowrank = True
 
     mf_trial = False
@@ -139,67 +169,99 @@ def test_pair_branch_batch_lowrank():
     numpy.random.seed(seed)
 
     options = {
-                'nelec': nelec,
-                'nbasis': nbasis,
-                'mu': mu,
-                'beta': beta,
-                'timestep': timestep,
-                'nwalkers': nwalkers,
-                'seed': seed,
-                'nsteps_per_block': nsteps_per_block,
-                'nblocks': nblocks,
-                'stabilize_freq': stabilize_freq,
-                'pop_control_freq': pop_control_freq,
-                'pop_control_method': pop_control_method,
-                'lowrank': lowrank,
-                'complex_integrals': complex_integrals,
-                'mf_trial': mf_trial,
-                'propagate': propagate,
-                'diagonal': diagonal,
-            }
-    
+        "nelec": nelec,
+        "nbasis": nbasis,
+        "mu": mu,
+        "beta": beta,
+        "timestep": timestep,
+        "nwalkers": nwalkers,
+        "seed": seed,
+        "nsteps_per_block": nsteps_per_block,
+        "nblocks": nblocks,
+        "stabilize_freq": stabilize_freq,
+        "pop_control_freq": pop_control_freq,
+        "pop_control_method": pop_control_method,
+        "lowrank": lowrank,
+        "complex_integrals": complex_integrals,
+        "mf_trial": mf_trial,
+        "propagate": propagate,
+        "diagonal": diagonal,
+    }
+
     # Test.
-    objs =  build_generic_test_case_handlers_mpi(
-            nelec, nbasis, mu, beta, timestep, mpi_handler, nwalkers=nwalkers, 
-            lowrank=lowrank, mf_trial=mf_trial, complex_integrals=complex_integrals, 
-            diagonal=diagonal, debug=debug, seed=seed, verbose=verbose)
-    trial = objs['trial']
-    hamiltonian = objs['hamiltonian']
-    walkers = objs['walkers']
-    propagator = objs['propagator']
-    pcontrol = ThermalPopController(nwalkers, nsteps_per_block, mpi_handler,
-                             pop_control_method=pop_control_method, verbose=verbose)
-    
+    objs = build_generic_test_case_handlers_mpi(
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        mpi_handler,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        diagonal=diagonal,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    hamiltonian = objs["hamiltonian"]
+    walkers = objs["walkers"]
+    propagator = objs["propagator"]
+    pcontrol = ThermalPopController(
+        nwalkers,
+        nsteps_per_block,
+        mpi_handler,
+        pop_control_method=pop_control_method,
+        verbose=verbose,
+    )
+
     # Legacy.
     legacy_objs = build_legacy_generic_test_case_handlers_mpi(
-                    hamiltonian, mpi_handler, nelec, mu, beta, timestep, 
-                    nwalkers=nwalkers, lowrank=lowrank, mf_trial=mf_trial,
-                    seed=seed, verbose=verbose)
-    legacy_system = legacy_objs['system']
-    legacy_trial = legacy_objs['trial']
-    legacy_hamiltonian = legacy_objs['hamiltonian']
-    legacy_walkers = legacy_objs['walkers']
-    legacy_propagator = legacy_objs['propagator']
-    
-    for block in range(nblocks): 
+        hamiltonian,
+        mpi_handler,
+        nelec,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_system = legacy_objs["system"]
+    legacy_trial = legacy_objs["trial"]
+    legacy_hamiltonian = legacy_objs["hamiltonian"]
+    legacy_walkers = legacy_objs["walkers"]
+    legacy_propagator = legacy_objs["propagator"]
+
+    for block in range(nblocks):
         for t in range(walkers.stack[0].nslice):
             propagator.propagate_walkers(walkers, hamiltonian, trial, debug=True)
             legacy_walkers = legacy_propagate_walkers(
-                                legacy_hamiltonian, legacy_trial, legacy_walkers, 
-                                legacy_propagator, xi=propagator.xi)
-            
+                legacy_hamiltonian,
+                legacy_trial,
+                legacy_walkers,
+                legacy_propagator,
+                xi=propagator.xi,
+            )
+
             if t > 0:
                 pcontrol.pop_control(walkers, mpi_handler.comm)
                 legacy_walkers.pop_control(mpi_handler.comm)
 
-        walkers.reset(trial) # Reset stack, weights, phase.
+        walkers.reset(trial)  # Reset stack, weights, phase.
         legacy_walkers.reset(legacy_trial)
 
     for iw in range(walkers.nwalkers):
         assert numpy.allclose(walkers.Ga[iw], legacy_walkers.walkers[iw].G[0])
         assert numpy.allclose(walkers.Gb[iw], legacy_walkers.walkers[iw].G[1])
         assert numpy.allclose(walkers.weight[iw], legacy_walkers.walkers[iw].weight)
-        assert numpy.allclose(walkers.unscaled_weight[iw], legacy_walkers.walkers[iw].unscaled_weight)
+        assert numpy.allclose(
+            walkers.unscaled_weight[iw], legacy_walkers.walkers[iw].unscaled_weight
+        )
 
 
 @pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
@@ -213,14 +275,14 @@ def test_comb_batch():
     nbasis = 10
 
     # Thermal AFQMC params.
-    mu = -10.
+    mu = -10.0
     beta = 0.1
     timestep = 0.01
     nwalkers = 12
     nblocks = 3
     # Must be fixed at 1 for Thermal AFQMC--legacy code overides whatever input!
     nsteps_per_block = 1
-    pop_control_method = 'comb'
+    pop_control_method = "comb"
     lowrank = False
 
     mf_trial = True
@@ -231,56 +293,87 @@ def test_comb_batch():
     numpy.random.seed(seed)
 
     # Test.
-    objs =  build_generic_test_case_handlers_mpi(
-            nelec, nbasis, mu, beta, timestep, mpi_handler, nwalkers=nwalkers, 
-            lowrank=lowrank, mf_trial=mf_trial, complex_integrals=complex_integrals, 
-            debug=debug, seed=seed, verbose=verbose)
-    trial = objs['trial']
-    hamiltonian = objs['hamiltonian']
-    walkers = objs['walkers']
-    propagator = objs['propagator']
-    pcontrol = ThermalPopController(nwalkers, nsteps_per_block, mpi_handler,
-                             pop_control_method=pop_control_method, verbose=verbose)
-    
+    objs = build_generic_test_case_handlers_mpi(
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        mpi_handler,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    hamiltonian = objs["hamiltonian"]
+    walkers = objs["walkers"]
+    propagator = objs["propagator"]
+    pcontrol = ThermalPopController(
+        nwalkers,
+        nsteps_per_block,
+        mpi_handler,
+        pop_control_method=pop_control_method,
+        verbose=verbose,
+    )
+
     # Legacy.
     legacy_objs = build_legacy_generic_test_case_handlers_mpi(
-                    hamiltonian, mpi_handler, nelec, mu, beta, timestep, 
-                    nwalkers=nwalkers, lowrank=lowrank, mf_trial=mf_trial,
-                    pop_control_method=pop_control_method, seed=seed, 
-                    verbose=verbose)
-    legacy_system = legacy_objs['system']
-    legacy_trial = legacy_objs['trial']
-    legacy_hamiltonian = legacy_objs['hamiltonian']
-    legacy_walkers = legacy_objs['walkers']
-    legacy_propagator = legacy_objs['propagator']
-    
-    for block in range(nblocks): 
+        hamiltonian,
+        mpi_handler,
+        nelec,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        pop_control_method=pop_control_method,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_system = legacy_objs["system"]
+    legacy_trial = legacy_objs["trial"]
+    legacy_hamiltonian = legacy_objs["hamiltonian"]
+    legacy_walkers = legacy_objs["walkers"]
+    legacy_propagator = legacy_objs["propagator"]
+
+    for block in range(nblocks):
         for t in range(walkers.stack[0].nslice):
             propagator.propagate_walkers(walkers, hamiltonian, trial, debug=True)
             legacy_walkers = legacy_propagate_walkers(
-                                legacy_hamiltonian, legacy_trial, legacy_walkers, 
-                                legacy_propagator, xi=propagator.xi)
-            
+                legacy_hamiltonian,
+                legacy_trial,
+                legacy_walkers,
+                legacy_propagator,
+                xi=propagator.xi,
+            )
+
             if t > 0:
                 pcontrol.pop_control(walkers, mpi_handler.comm)
                 legacy_walkers.pop_control(mpi_handler.comm)
 
-        walkers.reset(trial) # Reset stack, weights, phase.
+        walkers.reset(trial)  # Reset stack, weights, phase.
         legacy_walkers.reset(legacy_trial)
 
     for iw in range(walkers.nwalkers):
         assert numpy.allclose(walkers.Ga[iw], legacy_walkers.walkers[iw].G[0])
         assert numpy.allclose(walkers.Gb[iw], legacy_walkers.walkers[iw].G[1])
         assert numpy.allclose(walkers.weight[iw], legacy_walkers.walkers[iw].weight)
-        assert numpy.allclose(walkers.unscaled_weight[iw], legacy_walkers.walkers[iw].unscaled_weight)
+        assert numpy.allclose(
+            walkers.unscaled_weight[iw], legacy_walkers.walkers[iw].unscaled_weight
+        )
 
 
 # TODO: Lowrank code is WIP. See: https://github.com/JoonhoLee-Group/ipie/issues/302
-#@pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
-#@pytest.mark.unit
+# @pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
+# @pytest.mark.unit
 def test_comb_batch_lowrank():
     mpi_handler = MPIHandler()
-    
+
     # System params.
     nup = 5
     ndown = 5
@@ -288,14 +381,14 @@ def test_comb_batch_lowrank():
     nbasis = 10
 
     # Thermal AFQMC params.
-    mu = -10.
+    mu = -10.0
     beta = 0.1
     timestep = 0.01
     nwalkers = 12
     nblocks = 3
     # Must be fixed at 1 for Thermal AFQMC--legacy code overides whatever input!
     nsteps_per_block = 1
-    pop_control_method = 'comb'
+    pop_control_method = "comb"
     lowrank = True
 
     mf_trial = False
@@ -305,54 +398,86 @@ def test_comb_batch_lowrank():
     verbose = False if (comm.rank != 0) else True
     seed = 7
     numpy.random.seed(seed)
-    
+
     # Test.
-    objs =  build_generic_test_case_handlers_mpi(
-            nelec, nbasis, mu, beta, timestep, mpi_handler, nwalkers=nwalkers, 
-            lowrank=lowrank, mf_trial=mf_trial, complex_integrals=complex_integrals, 
-            diagonal=diagonal, debug=debug, seed=seed, verbose=verbose)
-    trial = objs['trial']
-    hamiltonian = objs['hamiltonian']
-    walkers = objs['walkers']
-    propagator = objs['propagator']
-    pcontrol = ThermalPopController(nwalkers, nsteps_per_block, mpi_handler, 
-                             pop_control_method=pop_control_method, verbose=verbose)
-    
+    objs = build_generic_test_case_handlers_mpi(
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        mpi_handler,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        diagonal=diagonal,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    hamiltonian = objs["hamiltonian"]
+    walkers = objs["walkers"]
+    propagator = objs["propagator"]
+    pcontrol = ThermalPopController(
+        nwalkers,
+        nsteps_per_block,
+        mpi_handler,
+        pop_control_method=pop_control_method,
+        verbose=verbose,
+    )
+
     # Legacy.
     legacy_objs = build_legacy_generic_test_case_handlers_mpi(
-                    hamiltonian, mpi_handler, nelec, mu, beta, timestep, 
-                    nwalkers=nwalkers, lowrank=lowrank, mf_trial=mf_trial,
-                    seed=seed, verbose=verbose)
-    legacy_system = legacy_objs['system']
-    legacy_trial = legacy_objs['trial']
-    legacy_hamiltonian = legacy_objs['hamiltonian']
-    legacy_walkers = legacy_objs['walkers']
-    legacy_propagator = legacy_objs['propagator']
-    
-    for block in range(nblocks): 
+        hamiltonian,
+        mpi_handler,
+        nelec,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_system = legacy_objs["system"]
+    legacy_trial = legacy_objs["trial"]
+    legacy_hamiltonian = legacy_objs["hamiltonian"]
+    legacy_walkers = legacy_objs["walkers"]
+    legacy_propagator = legacy_objs["propagator"]
+
+    for block in range(nblocks):
         for t in range(walkers.stack[0].nslice):
             propagator.propagate_walkers(walkers, hamiltonian, trial, debug=True)
             legacy_walkers = legacy_propagate_walkers(
-                                legacy_hamiltonian, legacy_trial, legacy_walkers, 
-                                legacy_propagator, xi=propagator.xi)
-            
+                legacy_hamiltonian,
+                legacy_trial,
+                legacy_walkers,
+                legacy_propagator,
+                xi=propagator.xi,
+            )
+
             if t > 0:
                 pcontrol.pop_control(walkers, mpi_handler.comm)
                 legacy_walkers.pop_control(mpi_handler.comm)
 
-        walkers.reset(trial) # Reset stack, weights, phase.
+        walkers.reset(trial)  # Reset stack, weights, phase.
         legacy_walkers.reset(legacy_trial)
 
     for iw in range(walkers.nwalkers):
         assert numpy.allclose(walkers.Ga[iw], legacy_walkers.walkers[iw].G[0])
         assert numpy.allclose(walkers.Gb[iw], legacy_walkers.walkers[iw].G[1])
         assert numpy.allclose(walkers.weight[iw], legacy_walkers.walkers[iw].weight)
-        assert numpy.allclose(walkers.unscaled_weight[iw], legacy_walkers.walkers[iw].unscaled_weight)
+        assert numpy.allclose(
+            walkers.unscaled_weight[iw], legacy_walkers.walkers[iw].unscaled_weight
+        )
 
 
 if __name__ == "__main__":
     test_pair_branch_batch()
     test_comb_batch()
-    
-    #test_pair_branch_batch_lowrank()
-    #test_comb_batch_lowrank()
+
+    # test_pair_branch_batch_lowrank()
+    # test_comb_batch_lowrank()

--- a/ipie/addons/thermal/walkers/tests/test_thermal_walkers.py
+++ b/ipie/addons/thermal/walkers/tests/test_thermal_walkers.py
@@ -23,6 +23,7 @@ from typing import Union
 try:
     from ipie.addons.thermal.utils.legacy_testing import build_legacy_generic_test_case_handlers
     from ipie.addons.thermal.utils.legacy_testing import legacy_propagate_walkers
+
     _no_cython = False
 
 except ModuleNotFoundError:
@@ -33,10 +34,13 @@ from ipie.addons.thermal.estimators.generic import local_energy_generic_cholesky
 from ipie.addons.thermal.estimators.thermal import one_rdm_from_G
 from ipie.addons.thermal.utils.testing import build_generic_test_case_handlers
 
-from ipie.legacy.estimators.generic import local_energy_generic_cholesky as legacy_local_energy_generic_cholesky
+from ipie.legacy.estimators.generic import (
+    local_energy_generic_cholesky as legacy_local_energy_generic_cholesky,
+)
 from ipie.legacy.estimators.thermal import one_rdm_from_G as legacy_one_rdm_from_G
 
 comm = MPI.COMM_WORLD
+
 
 @pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
 @pytest.mark.unit
@@ -48,7 +52,7 @@ def test_thermal_walkers_fullrank():
     nbasis = 10
 
     # Thermal AFQMC params.
-    mu = -10.
+    mu = -10.0
     beta = 0.1
     timestep = 0.01
     nwalkers = 10
@@ -60,43 +64,72 @@ def test_thermal_walkers_fullrank():
     verbose = True
     seed = 7
     numpy.random.seed(seed)
-    
+
     # Test.
-    objs =  build_generic_test_case_handlers(
-            nelec, nbasis, mu, beta, timestep, nwalkers=nwalkers, lowrank=lowrank, 
-            mf_trial=mf_trial, complex_integrals=complex_integrals, debug=debug, 
-            seed=seed, verbose=verbose)
-    trial = objs['trial']
-    hamiltonian = objs['hamiltonian']
-    walkers = objs['walkers']
-    
+    objs = build_generic_test_case_handlers(
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    hamiltonian = objs["hamiltonian"]
+    walkers = objs["walkers"]
+
     # Legacy.
     legacy_objs = build_legacy_generic_test_case_handlers(
-                    hamiltonian, comm, nelec, mu, beta, timestep, nwalkers=nwalkers, 
-                    lowrank=lowrank, mf_trial=mf_trial, seed=seed, verbose=verbose)
-    legacy_system = legacy_objs['system']
-    legacy_trial = legacy_objs['trial']
-    legacy_hamiltonian = legacy_objs['hamiltonian']
-    legacy_walkers = legacy_objs['walkers']
-    
+        hamiltonian,
+        comm,
+        nelec,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_system = legacy_objs["system"]
+    legacy_trial = legacy_objs["trial"]
+    legacy_hamiltonian = legacy_objs["hamiltonian"]
+    legacy_walkers = legacy_objs["walkers"]
+
     for iw in range(walkers.nwalkers):
-        P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]])) 
+        P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]]))
         eloc = local_energy_generic_cholesky(hamiltonian, P)
 
         legacy_P = legacy_one_rdm_from_G(numpy.array(legacy_walkers.walkers[iw].G))
         legacy_eloc = legacy_local_energy_generic_cholesky(
-                        legacy_system, legacy_hamiltonian, legacy_P)
+            legacy_system, legacy_hamiltonian, legacy_P
+        )
 
         numpy.testing.assert_almost_equal(legacy_eloc, eloc, decimal=10)
-        numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].G[0], walkers.Ga[iw], decimal=10)
-        numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].G[1], walkers.Gb[iw], decimal=10)
-        numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].stack.ovlp[0], walkers.stack[iw].ovlp[0], decimal=10)
-        numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].stack.ovlp[1], walkers.stack[iw].ovlp[1], decimal=10)
+        numpy.testing.assert_almost_equal(
+            legacy_walkers.walkers[iw].G[0], walkers.Ga[iw], decimal=10
+        )
+        numpy.testing.assert_almost_equal(
+            legacy_walkers.walkers[iw].G[1], walkers.Gb[iw], decimal=10
+        )
+        numpy.testing.assert_almost_equal(
+            legacy_walkers.walkers[iw].stack.ovlp[0], walkers.stack[iw].ovlp[0], decimal=10
+        )
+        numpy.testing.assert_almost_equal(
+            legacy_walkers.walkers[iw].stack.ovlp[1], walkers.stack[iw].ovlp[1], decimal=10
+        )
 
 
 # TODO: Lowrank code is WIP.
-#@pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
-#@pytest.mark.unit
+# @pytest.mark.skipif(_no_cython, reason="Need to build cython modules.")
+# @pytest.mark.unit
 def test_thermal_walkers_lowrank():
     # System params.
     nup = 5
@@ -105,7 +138,7 @@ def test_thermal_walkers_lowrank():
     nbasis = 10
 
     # Thermal AFQMC params.
-    mu = -10.
+    mu = -10.0
     beta = 0.1
     timestep = 0.01
     nwalkers = 10
@@ -118,39 +151,69 @@ def test_thermal_walkers_lowrank():
     verbose = True
     seed = 7
     numpy.random.seed(seed)
-    
+
     # Test.
-    objs =  build_generic_test_case_handlers(
-            nelec, nbasis, mu, beta, timestep, nwalkers=nwalkers, lowrank=lowrank, 
-            mf_trial=mf_trial, complex_integrals=complex_integrals, debug=debug, 
-            seed=seed, verbose=verbose)
-    trial = objs['trial']
-    hamiltonian = objs['hamiltonian']
-    walkers = objs['walkers']
-    
+    objs = build_generic_test_case_handlers(
+        nelec,
+        nbasis,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        complex_integrals=complex_integrals,
+        debug=debug,
+        seed=seed,
+        verbose=verbose,
+    )
+    trial = objs["trial"]
+    hamiltonian = objs["hamiltonian"]
+    walkers = objs["walkers"]
+
     # Legacy.
     legacy_objs = build_legacy_generic_test_case_handlers(
-                    hamiltonian, comm, nelec, mu, beta, timestep, nwalkers=nwalkers, 
-                    lowrank=lowrank, mf_trial=mf_trial, seed=seed, verbose=verbose)
-    legacy_system = legacy_objs['system']
-    legacy_trial = legacy_objs['trial']
-    legacy_hamiltonian = legacy_objs['hamiltonian']
-    legacy_walkers = legacy_objs['walkers']
-    
+        hamiltonian,
+        comm,
+        nelec,
+        mu,
+        beta,
+        timestep,
+        nwalkers=nwalkers,
+        lowrank=lowrank,
+        mf_trial=mf_trial,
+        seed=seed,
+        verbose=verbose,
+    )
+    legacy_system = legacy_objs["system"]
+    legacy_trial = legacy_objs["trial"]
+    legacy_hamiltonian = legacy_objs["hamiltonian"]
+    legacy_walkers = legacy_objs["walkers"]
+
     for iw in range(walkers.nwalkers):
-        P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]])) 
+        P = one_rdm_from_G(numpy.array([walkers.Ga[iw], walkers.Gb[iw]]))
         eloc = local_energy_generic_cholesky(hamiltonian, P)
 
         legacy_P = legacy_one_rdm_from_G(numpy.array(legacy_walkers.walkers[iw].G))
         legacy_eloc = legacy_local_energy_generic_cholesky(
-                        legacy_system, legacy_hamiltonian, legacy_P)
+            legacy_system, legacy_hamiltonian, legacy_P
+        )
 
         numpy.testing.assert_almost_equal(legacy_eloc, eloc, decimal=10)
-        numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].G[0], walkers.Ga[iw], decimal=10)
-        numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].G[1], walkers.Gb[iw], decimal=10)
-        numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].stack.ovlp[0], walkers.stack[iw].ovlp[0], decimal=10)
-        numpy.testing.assert_almost_equal(legacy_walkers.walkers[iw].stack.ovlp[1], walkers.stack[iw].ovlp[1], decimal=10)
+        numpy.testing.assert_almost_equal(
+            legacy_walkers.walkers[iw].G[0], walkers.Ga[iw], decimal=10
+        )
+        numpy.testing.assert_almost_equal(
+            legacy_walkers.walkers[iw].G[1], walkers.Gb[iw], decimal=10
+        )
+        numpy.testing.assert_almost_equal(
+            legacy_walkers.walkers[iw].stack.ovlp[0], walkers.stack[iw].ovlp[0], decimal=10
+        )
+        numpy.testing.assert_almost_equal(
+            legacy_walkers.walkers[iw].stack.ovlp[1], walkers.stack[iw].ovlp[1], decimal=10
+        )
+
 
 if __name__ == "__main__":
     test_thermal_walkers_fullrank()
-    #test_thermal_walkers_lowrank()
+    # test_thermal_walkers_lowrank()

--- a/ipie/estimators/energy.py
+++ b/ipie/estimators/energy.py
@@ -15,6 +15,8 @@
 # Author: Fionn Malone <fmalone@google.com>
 #
 
+from typing import Union
+
 import plum
 
 from ipie.estimators.estimator_base import EstimatorBase
@@ -42,7 +44,6 @@ from ipie.trial_wavefunction.particle_hole import (
 from ipie.trial_wavefunction.single_det import SingleDet
 from ipie.utils.backend import arraylib as xp
 from ipie.walkers.uhf_walkers import UHFWalkers
-from typing import Union
 
 
 @plum.dispatch
@@ -133,7 +134,7 @@ class EnergyEstimator(EstimatorBase):
         self.print_to_stdout = True
         self.ascii_filename = filename
 
-    def compute_estimator(self, system, walkers, hamiltonian, trial, istep=1):
+    def compute_estimator(self, system=None, walkers=None, hamiltonian=None, trial=None):
         trial.calc_greens_function(walkers)
         # Need to be able to dispatch here
         energy = local_energy(system, hamiltonian, walkers, trial)

--- a/ipie/estimators/estimator_base.py
+++ b/ipie/estimators/estimator_base.py
@@ -15,13 +15,13 @@
 # Author: Fionn Malone <fmalone@google.com>
 #
 
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
-from ipie.utils.io import format_fixed_width_strings, format_fixed_width_floats
 from ipie.utils.backend import arraylib as xp
 from ipie.utils.backend import to_host
+from ipie.utils.io import format_fixed_width_floats, format_fixed_width_strings
 
 
 class EstimatorBase(metaclass=ABCMeta):
@@ -78,7 +78,7 @@ class EstimatorBase(metaclass=ABCMeta):
         size = 0
         for _, v in self._data.items():
             if isinstance(v, np.ndarray):
-                size += np.prod(v.shape)
+                size += int(np.prod(v.shape))
             else:
                 size += 1
         return size
@@ -89,8 +89,9 @@ class EstimatorBase(metaclass=ABCMeta):
         self._shape = shape
 
     @abstractmethod
-    def compute_estimator(self, system, walkers, hamiltonian, trial) -> np.ndarray:
-        ...
+    def compute_estimator(
+        self, system=None, walkers=None, hamiltonian=None, trial=None
+    ) -> np.ndarray: ...
 
     @property
     def names(self):
@@ -142,5 +143,4 @@ class EstimatorBase(metaclass=ABCMeta):
             else:
                 self._data[k] = 0.0j
 
-    def post_reduce_hook(self, data) -> None:
-        ...
+    def post_reduce_hook(self, data) -> None: ...

--- a/ipie/estimators/generic.py
+++ b/ipie/estimators/generic.py
@@ -33,9 +33,7 @@ def local_energy_generic_opt(system, G, Ghalf=None, eri=None):
     assert eri is not None
 
     vipjq_aa = eri[0, : na**2 * M**2].reshape((na, M, na, M))
-    vipjq_bb = eri[0, na**2 * M**2 : na**2 * M**2 + nb**2 * M**2].reshape(
-        (nb, M, nb, M)
-    )
+    vipjq_bb = eri[0, na**2 * M**2 : na**2 * M**2 + nb**2 * M**2].reshape((nb, M, nb, M))
     vipjq_ab = eri[0, na**2 * M**2 + nb**2 * M**2 :].reshape((na, M, nb, M))
 
     Ga, Gb = Ghalf[0], Ghalf[1]

--- a/ipie/estimators/handler.py
+++ b/ipie/estimators/handler.py
@@ -190,7 +190,7 @@ class EstimatorHandler(object):
         self.index = self.index + 1
         self.filename = self.basename + f".{self.index}.h5"
 
-    def compute_estimators(self, comm, system, hamiltonian, trial, walker_batch):
+    def compute_estimators(self, system=None, hamiltonian=None, trial=None, walker_batch=None):
         """Update estimators with bached psi
 
         Parameters
@@ -201,7 +201,9 @@ class EstimatorHandler(object):
         # TODO: generalize for different block groups (loop over groups)
         offset = self.num_walker_props
         for k, e in self.items():
-            e.compute_estimator(system, walker_batch, hamiltonian, trial)
+            e.compute_estimator(
+                system=system, walkers=walker_batch, hamiltonian=hamiltonian, trial=trial
+            )
             start = offset + self.get_offset(k)
             end = start + int(self[k].size)
             self.local_estimates[start:end] += e.data

--- a/ipie/estimators/tests/test_estimators.py
+++ b/ipie/estimators/tests/test_estimators.py
@@ -72,5 +72,5 @@ def test_estimator_handler():
         handler["energy1"] = estim
         handler.json_string = ""
         handler.initialize(comm)
-        handler.compute_estimators(comm, system, ham, trial, walker_batch)
-        handler.compute_estimators(comm, system, ham, trial, walker_batch)
+        handler.compute_estimators(system, ham, trial, walker_batch)
+        handler.compute_estimators(system, ham, trial, walker_batch)

--- a/ipie/qmc/afqmc.py
+++ b/ipie/qmc/afqmc.py
@@ -17,6 +17,7 @@
 #
 
 """Driver to perform AFQMC calculation"""
+import abc
 import json
 import time
 import uuid
@@ -41,32 +42,8 @@ from ipie.walkers.pop_controller import PopController
 from ipie.walkers.walkers_dispatch import get_initial_walker, UHFWalkersTrial
 
 
-class AFQMC(object):
-    """AFQMC driver.
-
-    Parameters
-    ----------
-    system :
-        System class. TODO Remove this?
-    hamiltonian :
-        Hamiltonian describing the system.
-    trial :
-        Trial wavefunction
-    walkers :
-        Walkers used for open ended random walk.
-    propagator :
-        Class describing how to propagate walkers.
-    params :
-        Parameters of simulation. See QMCParams for description.
-    verbose : bool
-        How much information to print.
-
-    Attributes
-    ----------
-    _parallel_rng_seed : int
-        Seed deduced from params.rng_seed which is generally different on each
-            MPI process.
-    """
+class AFQMCBase(metaclass=abc.ABCMeta):
+    """Basic interface for AFQMC Driver"""
 
     def __init__(
         self,
@@ -92,187 +69,16 @@ class AFQMC(object):
         self._init_time = time.time()
         self._parallel_rng_seed = set_rng_seed(params.rng_seed, self.mpi_handler.comm)
 
-    @staticmethod
-    # TODO: wavefunction type, trial type, hamiltonian type
-    def build(
-        num_elec: Tuple[int, int],
-        hamiltonian,
-        trial_wavefunction,
+    @abc.abstractmethod
+    def run(
+        self,
         walkers=None,
-        num_walkers: int = 100,
-        seed: int = None,
-        num_steps_per_block: int = 25,
-        num_blocks: int = 100,
-        timestep: float = 0.005,
-        stabilize_freq=5,
-        pop_control_freq=5,
+        estimator_filename=None,
         verbose=True,
-        mpi_handler=None,
-    ) -> "AFQMC":
-        """Factory method to build AFQMC driver from hamiltonian and trial wavefunction.
-
-        Parameters
-        ----------
-        num_elec: tuple(int, int)
-            Number of alpha and beta electrons.
-        hamiltonian :
-            Hamiltonian describing the system.
-        trial_wavefunction :
-            Trial wavefunction
-        num_walkers : int
-            Number of walkers per MPI process used in the simulation. The TOTAL
-                number of walkers is num_walkers * number of processes.
-        num_steps_per_block : int
-            Number of Monte Carlo steps before estimators are evaluatied.
-                Default 25.
-        num_blocks : int
-            Number of blocks to perform. Total number of steps = num_blocks *
-                num_steps_per_block.
-        timestep : float
-            Imaginary timestep. Default 0.005.
-        stabilize_freq : float
-            Frequency at which to perform QR factorization of walkers (in units
-                of steps.) Default 25.
-        pop_control_freq : int
-            Frequency at which to perform population control (in units of
-                steps.) Default 25.
-        verbose : bool
-            Log verbosity. Default True i.e. print information to stdout.
-        """
-        if mpi_handler is None:
-            mpi_handler = MPIHandler()
-            comm = mpi_handler.comm
-        else:
-            comm = mpi_handler.comm
-        params = QMCParams(
-            num_walkers=num_walkers,
-            total_num_walkers=num_walkers * comm.size,
-            num_blocks=num_blocks,
-            num_steps_per_block=num_steps_per_block,
-            timestep=timestep,
-            num_stblz=stabilize_freq,
-            pop_control_freq=pop_control_freq,
-            rng_seed=seed,
-        )
-        # 2. Calculation objects.
-        system = Generic(num_elec)
-        # TODO: do logic and logging in the function.
-        if trial_wavefunction.compute_trial_energy:
-            trial_wavefunction.calculate_energy(system, hamiltonian)
-            trial_wavefunction.e1b = comm.bcast(trial_wavefunction.e1b, root=0)
-            trial_wavefunction.e2b = comm.bcast(trial_wavefunction.e2b, root=0)
-        comm.barrier()
-        if walkers is None:
-            _, initial_walker = get_initial_walker(trial_wavefunction)
-            # TODO this is a factory method not a class
-            walkers = UHFWalkersTrial(
-                trial_wavefunction,
-                initial_walker,
-                system.nup,
-                system.ndown,
-                hamiltonian.nbasis,
-                num_walkers,
-                mpi_handler,
-            )
-            walkers.build(
-                trial_wavefunction
-            )  # any intermediates that require information from trial
-        # TODO: this is a factory not a class
-        propagator = Propagator[type(hamiltonian)](params.timestep)
-        propagator.build(hamiltonian, trial_wavefunction, walkers, mpi_handler)
-        return AFQMC(
-            system,
-            hamiltonian,
-            trial_wavefunction,
-            walkers,
-            propagator,
-            mpi_handler,
-            params,
-            verbose=(verbose and comm.rank == 0),
-        )
-
-    @staticmethod
-    # TODO: wavefunction type, trial type, hamiltonian type
-    def build_from_hdf5(
-        num_elec: Tuple[int, int],
-        ham_file,
-        wfn_file,
-        num_walkers: int = 100,
-        seed: int = None,
-        num_steps_per_block: int = 25,
-        num_blocks: int = 100,
-        timestep: float = 0.005,
-        stabilize_freq=5,
-        pop_control_freq=5,
-        num_dets_chunk=1,
-        num_dets_for_trial_props=100,
-        pack_cholesky=True,
-        verbose=True,
-    ) -> "AFQMC":
-        """Factory method to build AFQMC driver from hamiltonian and trial wavefunction.
-
-        Parameters
-        ----------
-        num_elec: tuple(int, int)
-            Number of alpha and beta electrons.
-        ham_file : str
-            Path to Hamiltonian describing the system.
-        wfn_file : str
-            Path to Trial wavefunction
-        num_walkers : int
-            Number of walkers per MPI process used in the simulation. The TOTAL
-                number of walkers is num_walkers * number of processes.
-        num_steps_per_block : int
-            Number of Monte Carlo steps before estimators are evaluatied.
-                Default 25.
-        num_blocks : int
-            Number of blocks to perform. Total number of steps = num_blocks *
-                num_steps_per_block.
-        timestep : float
-            Imaginary timestep. Default 0.005.
-        stabilize_freq : float
-            Frequency at which to perform QR factorization of walkers (in units
-                of steps.) Default 25.
-        pop_control_freq : int
-            Frequency at which to perform population control (in units of
-                steps.) Default 25.
-        num_det_chunks : int
-            Size of chunks of determinants to process during batching. Default=1 (no batching).
-        num_dets_for_trial_props: int
-            Number of determinants to use to evaluate trial wavefunction properties.
-        pack_cholesky : bool
-            Use symmetry to reduce memory consumption of integrals. Default True.
-        verbose : bool
-            Log verbosity. Default True i.e. print information to stdout.
-        """
-        mpi_handler = MPIHandler()
-        _verbose = verbose and mpi_handler.comm.rank == 0
-        ham = get_hamiltonian(
-            ham_file, mpi_handler.scomm, verbose=_verbose, pack_chol=pack_cholesky
-        )
-        trial = get_trial_wavefunction(
-            num_elec,
-            ham.nbasis,
-            wfn_file,
-            ndet_chunks=num_dets_chunk,
-            ndets_props=num_dets_for_trial_props,
-            verbose=_verbose,
-        )
-        trial.half_rotate(ham, mpi_handler.scomm)
-        return AFQMC.build(
-            trial.nelec,
-            ham,
-            trial,
-            num_walkers=num_walkers,
-            seed=seed,
-            num_steps_per_block=num_steps_per_block,
-            num_blocks=num_blocks,
-            timestep=timestep,
-            stabilize_freq=stabilize_freq,
-            pop_control_freq=pop_control_freq,
-            verbose=verbose,
-            mpi_handler=mpi_handler,
-        )
+        additional_estimators: Optional[Dict[str, EstimatorBase]] = None,
+    ):
+        """Code to run the AFQMC calculation."""
+        raise NotImplementedError
 
     def distribute_hamiltonian(self):
         if self.mpi_handler.nmembers > 1:
@@ -318,39 +124,6 @@ class AFQMC(object):
             print(f"# MPI communicator : {type(self.mpi_handler.comm)}")
             print(f"# Available memory on the node is {mem_avail:4.3f} GB")
 
-    def setup_estimators(
-        self, filename, additional_estimators: Optional[Dict[str, EstimatorBase]] = None
-    ):
-        self.accumulators = WalkerAccumulator(
-            ["Weight", "WeightFactor", "HybridEnergy"], self.params.num_steps_per_block
-        )
-        comm = self.mpi_handler.comm
-        self.estimators = EstimatorHandler(
-            self.mpi_handler.comm,
-            self.system,
-            self.hamiltonian,
-            self.trial,
-            walker_state=self.accumulators,
-            verbose=(comm.rank == 0 and self.verbose),
-            filename=filename,
-        )
-        if additional_estimators is not None:
-            for k, v in additional_estimators.items():
-                self.estimators[k] = v
-        # TODO: Move this to estimator and log uuid etc in serialization
-        json.encoder.FLOAT_REPR = lambda o: format(o, ".6f")
-        json_string = to_json(self)
-        self.estimators.json_string = json_string
-
-        self.estimators.initialize(comm)
-        # Calculate estimates for initial distribution of walkers.
-        self.estimators.compute_estimators(
-            comm, self.system, self.hamiltonian, self.trial, self.walkers
-        )
-        self.accumulators.update(self.walkers)
-        self.estimators.print_block(comm, 0, self.accumulators)
-        self.accumulators.zero()
-
     def setup_timers(self):
         # TODO: Better timer
         self.tsetup = 0
@@ -371,133 +144,6 @@ class AFQMC(object):
         self.tpopc_comm = 0
         self.tpopc_non_comm = 0
         self.tstep = 0
-
-    def run(
-        self,
-        psi=None,
-        estimator_filename=None,
-        verbose=True,
-        additional_estimators: Optional[Dict[str, EstimatorBase]] = None,
-    ):
-        """Perform AFQMC simulation on state object using open-ended random walk.
-
-        Parameters
-        ----------
-        psi : :class:`pie.walker.Walkers` object
-            Initial wavefunction / distribution of walkers. Default None.
-        estimator_filename : str
-            File to write estimates to.
-        additional_estimators : dict
-            Dictionary of additional estimators to evaluate.
-        """
-        self.setup_timers()
-        tzero_setup = time.time()
-        if psi is not None:
-            self.walkers = psi
-        self.setup_timers()
-        eshift = 0.0
-        self.walkers.orthogonalise()
-
-        self.pcontrol = PopController(
-            self.params.num_walkers,
-            self.params.num_steps_per_block,
-            self.mpi_handler,
-            verbose=self.verbose,
-        )
-
-        self.get_env_info()
-        # self.distribute_hamiltonian()
-        self.copy_to_gpu()
-
-        # from ipie.utils.backend import get_device_memory
-        # used_bytes, total_bytes = get_device_memory()
-        # print(f"# after distribute {comm.rank}: using {used_bytes/1024**3} GB out of {total_bytes/1024**3} GB memory on GPU")
-        self.setup_estimators(estimator_filename, additional_estimators=additional_estimators)
-
-        # TODO: This magic value of 2 is pretty much never controlled on input.
-        # Moreover I'm not convinced having a two stage shift update actually
-        # matters at all.
-        num_eqlb_steps = 2.0 / self.params.timestep
-
-        total_steps = self.params.num_steps_per_block * self.params.num_blocks
-
-        synchronize()
-        comm = self.mpi_handler.comm
-        self.tsetup += time.time() - tzero_setup
-
-        for step in range(1, total_steps + 1):
-            synchronize()
-            start_step = time.time()
-            if step % self.params.num_stblz == 0:
-                start = time.time()
-                self.walkers.orthogonalise()
-                synchronize()
-                self.tortho += time.time() - start
-            start = time.time()
-
-            self.propagator.propagate_walkers(self.walkers, self.hamiltonian, self.trial, eshift)
-
-            self.tprop_fbias = self.propagator.timer.tfbias
-            self.tprop_ovlp = self.propagator.timer.tovlp
-            self.tprop_update = self.propagator.timer.tupdate
-            self.tprop_gf = self.propagator.timer.tgf
-            self.tprop_vhs = self.propagator.timer.tvhs
-            self.tprop_gemm = self.propagator.timer.tgemm
-
-            start_clip = time.time()
-            if step > 1:
-                wbound = self.pcontrol.total_weight * 0.10
-                xp.clip(
-                    self.walkers.weight, a_min=-wbound, a_max=wbound, out=self.walkers.weight
-                )  # in-place clipping
-
-            synchronize()
-            self.tprop_clip += time.time() - start_clip
-
-            start_barrier = time.time()
-            if step % self.params.pop_control_freq == 0:
-                comm.Barrier()
-            self.tprop_barrier += time.time() - start_barrier
-
-            self.tprop += time.time() - start
-            if step % self.params.pop_control_freq == 0:
-                start = time.time()
-                self.pcontrol.pop_control(self.walkers, comm)
-                synchronize()
-                self.tpopc += time.time() - start
-                self.tpopc_send = self.pcontrol.timer.send_time
-                self.tpopc_recv = self.pcontrol.timer.recv_time
-                self.tpopc_comm = self.pcontrol.timer.communication_time
-                self.tpopc_non_comm = self.pcontrol.timer.non_communication_time
-
-            # accumulate weight, hybrid energy etc. across block
-            start = time.time()
-            self.accumulators.update(self.walkers)
-            synchronize()
-            self.testim += time.time() - start  # we dump this time into estimator
-            # calculate estimators
-            start = time.time()
-            if step % self.params.num_steps_per_block == 0:
-                self.estimators.compute_estimators(
-                    comm, self.system, self.hamiltonian, self.trial, self.walkers
-                )
-                self.estimators.print_block(
-                    comm, step // self.params.num_steps_per_block, self.accumulators
-                )
-                self.accumulators.zero()
-            synchronize()
-            self.testim += time.time() - start
-
-            # restart write features disabled
-            # if self.walkers.write_restart and step % self.walkers.write_freq == 0:
-            #     self.walkers.write_walkers_batch(comm)
-
-            if step < num_eqlb_steps:
-                eshift = self.accumulators.eshift
-            else:
-                eshift += self.accumulators.eshift - eshift
-            synchronize()
-            self.tstep += time.time() - start_step
 
     def finalise(self, verbose=False):
         """Tidy up.
@@ -602,3 +248,386 @@ class AFQMC(object):
         continuous = "continuous" in hs_type
         twist = system.ktwist.all() is not None
         return continuous or twist
+
+
+class AFQMC(AFQMCBase):
+    """AFQMC driver for zero temperature open ended random walk.
+
+    Parameters
+    ----------
+    system :
+        System class. TODO Remove this?
+    hamiltonian :
+        Hamiltonian describing the system.
+    trial :
+        Trial wavefunction
+    walkers :
+        Walkers used for open ended random walk.
+    propagator :
+        Class describing how to propagate walkers.
+    params :
+        Parameters of simulation. See QMCParams for description.
+    verbose : bool
+        How much information to print.
+
+    Attributes
+    ----------
+    _parallel_rng_seed : int
+        Seed deduced from params.rng_seed which is generally different on each
+            MPI process.
+    """
+
+    def __init__(
+        self,
+        system,
+        hamiltonian,
+        trial,
+        walkers,
+        propagator,
+        mpi_handler,
+        params: QMCParams,
+        verbose: int = 0,
+    ):
+        super().__init__(
+            system, hamiltonian, trial, walkers, propagator, mpi_handler, params, verbose
+        )
+
+    @staticmethod
+    # TODO: wavefunction type, trial type, hamiltonian type
+    def build(
+        num_elec: Tuple[int, int],
+        hamiltonian,
+        trial_wavefunction,
+        walkers=None,
+        num_walkers: int = 100,
+        seed: Optional[int] = None,
+        num_steps_per_block: int = 25,
+        num_blocks: int = 100,
+        timestep: float = 0.005,
+        stabilize_freq=5,
+        pop_control_freq=5,
+        verbose=True,
+        mpi_handler=None,
+    ) -> "AFQMC":
+        """Factory method to build AFQMC driver from hamiltonian and trial wavefunction.
+
+        Parameters
+        ----------
+        num_elec: tuple(int, int)
+            Number of alpha and beta electrons.
+        hamiltonian :
+            Hamiltonian describing the system.
+        trial_wavefunction:
+            Trial wavefunction
+        num_walkers : int
+            Number of walkers per MPI process used in the simulation. The TOTAL
+                number of walkers is num_walkers * number of processes.
+        num_steps_per_block : int
+            Number of Monte Carlo steps before estimators are evaluatied.
+                Default 25.
+        num_blocks : int
+            Number of blocks to perform. Total number of steps = num_blocks *
+                num_steps_per_block.
+        timestep : float
+            Imaginary timestep. Default 0.005.
+        stabilize_freq : float
+            Frequency at which to perform QR factorization of walkers (in units
+                of steps.) Default 25.
+        pop_control_freq : int
+            Frequency at which to perform population control (in units of
+                steps.) Default 25.
+        verbose : bool
+            Log verbosity. Default True i.e. print information to stdout.
+        """
+        if mpi_handler is None:
+            mpi_handler = MPIHandler()
+            comm = mpi_handler.comm
+        else:
+            comm = mpi_handler.comm
+        params = QMCParams(
+            num_walkers=num_walkers,
+            total_num_walkers=num_walkers * comm.size,
+            num_blocks=num_blocks,
+            num_steps_per_block=num_steps_per_block,
+            timestep=timestep,
+            num_stblz=stabilize_freq,
+            pop_control_freq=pop_control_freq,
+            rng_seed=seed,
+        )
+        # 2. Calculation objects.
+        system = Generic(num_elec)
+        # TODO: do logic and logging in the function.
+        if trial_wavefunction.compute_trial_energy:
+            trial_wavefunction.calculate_energy(system, hamiltonian)
+            trial_wavefunction.e1b = comm.bcast(trial_wavefunction.e1b, root=0)
+            trial_wavefunction.e2b = comm.bcast(trial_wavefunction.e2b, root=0)
+        comm.barrier()
+        if walkers is None:
+            _, initial_walker = get_initial_walker(trial_wavefunction)
+            # TODO this is a factory method not a class
+            walkers = UHFWalkersTrial(
+                trial_wavefunction,
+                initial_walker,
+                system.nup,
+                system.ndown,
+                hamiltonian.nbasis,
+                num_walkers,
+                mpi_handler,
+            )
+            walkers.build(
+                trial_wavefunction
+            )  # any intermediates that require information from trial_wavefunction
+        # TODO: this is a factory not a class
+        propagator = Propagator[type(hamiltonian)](params.timestep)
+        propagator.build(hamiltonian, trial_wavefunction, walkers, mpi_handler)
+        return AFQMC(
+            system,
+            hamiltonian,
+            trial_wavefunction,
+            walkers,
+            propagator,
+            mpi_handler,
+            params,
+            verbose=(verbose and comm.rank == 0),
+        )
+
+    @staticmethod
+    # TODO: wavefunction type, trial type, hamiltonian type
+    def build_from_hdf5(
+        num_elec: Tuple[int, int],
+        ham_file,
+        wfn_file,
+        num_walkers: int = 100,
+        seed: Optional[int] = None,
+        num_steps_per_block: int = 25,
+        num_blocks: int = 100,
+        timestep: float = 0.005,
+        stabilize_freq=5,
+        pop_control_freq=5,
+        num_dets_chunk=1,
+        num_dets_for_trial_props=100,
+        pack_cholesky=True,
+        verbose=True,
+    ) -> "AFQMC":
+        """Factory method to build AFQMC driver from hamiltonian and trial wavefunction.
+
+        Parameters
+        ----------
+        num_elec: tuple(int, int)
+            Number of alpha and beta electrons.
+        ham_file : str
+            Path to Hamiltonian describing the system.
+        wfn_file : str
+            Path to Trial wavefunction
+        num_walkers : int
+            Number of walkers per MPI process used in the simulation. The TOTAL
+                number of walkers is num_walkers * number of processes.
+        num_steps_per_block : int
+            Number of Monte Carlo steps before estimators are evaluatied.
+                Default 25.
+        num_blocks : int
+            Number of blocks to perform. Total number of steps = num_blocks *
+                num_steps_per_block.
+        timestep : float
+            Imaginary timestep. Default 0.005.
+        stabilize_freq : float
+            Frequency at which to perform QR factorization of walkers (in units
+                of steps.) Default 25.
+        pop_control_freq : int
+            Frequency at which to perform population control (in units of
+                steps.) Default 25.
+        num_det_chunks : int
+            Size of chunks of determinants to process during batching. Default=1 (no batching).
+        num_dets_for_trial_props: int
+            Number of determinants to use to evaluate trial wavefunction properties.
+        pack_cholesky : bool
+            Use symmetry to reduce memory consumption of integrals. Default True.
+        verbose : bool
+            Log verbosity. Default True i.e. print information to stdout.
+        """
+        mpi_handler = MPIHandler()
+        _verbose = verbose and mpi_handler.comm.rank == 0
+        ham = get_hamiltonian(
+            ham_file, mpi_handler.scomm, verbose=_verbose, pack_chol=pack_cholesky
+        )
+        trial = get_trial_wavefunction(
+            num_elec,
+            ham.nbasis,
+            wfn_file,
+            ndet_chunks=num_dets_chunk,
+            ndets_props=num_dets_for_trial_props,
+            verbose=_verbose,
+        )
+        trial.half_rotate(ham, mpi_handler.scomm)
+        return AFQMC.build(
+            trial.nelec,
+            ham,
+            trial,
+            num_walkers=num_walkers,
+            seed=seed,
+            num_steps_per_block=num_steps_per_block,
+            num_blocks=num_blocks,
+            timestep=timestep,
+            stabilize_freq=stabilize_freq,
+            pop_control_freq=pop_control_freq,
+            verbose=verbose,
+            mpi_handler=mpi_handler,
+        )
+
+    def setup_estimators(
+        self, filename, additional_estimators: Optional[Dict[str, EstimatorBase]] = None
+    ):
+        self.accumulators = WalkerAccumulator(
+            ["Weight", "WeightFactor", "HybridEnergy"], self.params.num_steps_per_block
+        )
+        comm = self.mpi_handler.comm
+        self.estimators = EstimatorHandler(
+            self.mpi_handler.comm,
+            self.system,
+            self.hamiltonian,
+            self.trial,
+            walker_state=self.accumulators,
+            verbose=(comm.rank == 0 and self.verbose),
+            filename=filename,
+        )
+        if additional_estimators is not None:
+            for k, v in additional_estimators.items():
+                self.estimators[k] = v
+        # TODO: Move this to estimator and log uuid etc in serialization
+        json.encoder.FLOAT_REPR = lambda o: format(o, ".6f")
+        json_string = to_json(self)
+        self.estimators.json_string = json_string
+
+        self.estimators.initialize(comm)
+        # Calculate estimates for initial distribution of walkers.
+        self.estimators.compute_estimators(self.system, self.hamiltonian, self.trial, self.walkers)
+        self.accumulators.update(self.walkers)
+        self.estimators.print_block(comm, 0, self.accumulators)
+        self.accumulators.zero()
+
+    def run(
+        self,
+        walkers=None,
+        estimator_filename=None,
+        verbose=True,
+        additional_estimators: Optional[Dict[str, EstimatorBase]] = None,
+    ):
+        """Perform AFQMC simulation on state object using open-ended random walk.
+
+        Parameters
+        ----------
+        walkers : :class:`pie.walker.Walkers` object
+            Initial wavefunction / distribution of walkers. Default None.
+        estimator_filename : str
+            File to write estimates to.
+        additional_estimators : dict
+            Dictionary of additional estimators to evaluate.
+        """
+        self.setup_timers()
+        tzero_setup = time.time()
+        if walkers is not None:
+            self.walkers = walkers
+        self.setup_timers()
+        eshift = 0.0
+        self.walkers.orthogonalise()
+
+        self.pcontrol = PopController(
+            self.params.num_walkers,
+            self.params.num_steps_per_block,
+            self.mpi_handler,
+            verbose=self.verbose,
+        )
+
+        self.get_env_info()
+        # self.distribute_hamiltonian()
+        self.copy_to_gpu()
+
+        # from ipie.utils.backend import get_device_memory
+        # used_bytes, total_bytes = get_device_memory()
+        # print(f"# after distribute {comm.rank}: using {used_bytes/1024**3} GB out of {total_bytes/1024**3} GB memory on GPU")
+        self.setup_estimators(estimator_filename, additional_estimators=additional_estimators)
+
+        # TODO: This magic value of 2 is pretty much never controlled on input.
+        # Moreover I'm not convinced having a two stage shift update actually
+        # matters at all.
+        num_eqlb_steps = 2.0 / self.params.timestep
+
+        total_steps = self.params.num_steps_per_block * self.params.num_blocks
+
+        synchronize()
+        comm = self.mpi_handler.comm
+        self.tsetup += time.time() - tzero_setup
+
+        for step in range(1, total_steps + 1):
+            synchronize()
+            start_step = time.time()
+            if step % self.params.num_stblz == 0:
+                start = time.time()
+                self.walkers.orthogonalise()
+                synchronize()
+                self.tortho += time.time() - start
+            start = time.time()
+
+            self.propagator.propagate_walkers(self.walkers, self.hamiltonian, self.trial, eshift)
+
+            self.tprop_fbias = self.propagator.timer.tfbias
+            self.tprop_ovlp = self.propagator.timer.tovlp
+            self.tprop_update = self.propagator.timer.tupdate
+            self.tprop_gf = self.propagator.timer.tgf
+            self.tprop_vhs = self.propagator.timer.tvhs
+            self.tprop_gemm = self.propagator.timer.tgemm
+
+            start_clip = time.time()
+            if step > 1:
+                wbound = self.pcontrol.total_weight * 0.10
+                xp.clip(
+                    self.walkers.weight, a_min=-wbound, a_max=wbound, out=self.walkers.weight
+                )  # in-place clipping
+
+            synchronize()
+            self.tprop_clip += time.time() - start_clip
+
+            start_barrier = time.time()
+            if step % self.params.pop_control_freq == 0:
+                comm.Barrier()
+            self.tprop_barrier += time.time() - start_barrier
+
+            self.tprop += time.time() - start
+            if step % self.params.pop_control_freq == 0:
+                start = time.time()
+                self.pcontrol.pop_control(self.walkers, comm)
+                synchronize()
+                self.tpopc += time.time() - start
+                self.tpopc_send = self.pcontrol.timer.send_time
+                self.tpopc_recv = self.pcontrol.timer.recv_time
+                self.tpopc_comm = self.pcontrol.timer.communication_time
+                self.tpopc_non_comm = self.pcontrol.timer.non_communication_time
+
+            # accumulate weight, hybrid energy etc. across block
+            start = time.time()
+            self.accumulators.update(self.walkers)
+            synchronize()
+            self.testim += time.time() - start  # we dump this time into estimator
+            # calculate estimators
+            start = time.time()
+            if step % self.params.num_steps_per_block == 0:
+                self.estimators.compute_estimators(
+                    self.system, self.hamiltonian, self.trial, self.walkers
+                )
+                self.estimators.print_block(
+                    comm, step // self.params.num_steps_per_block, self.accumulators
+                )
+                self.accumulators.zero()
+            synchronize()
+            self.testim += time.time() - start
+
+            # restart write features disabled
+            # if self.walkers.write_restart and step % self.walkers.write_freq == 0:
+            #     self.walkers.write_walkers_batch(comm)
+
+            if step < num_eqlb_steps:
+                eshift = self.accumulators.eshift
+            else:
+                eshift += self.accumulators.eshift - eshift
+            synchronize()
+            self.tstep += time.time() - start_step

--- a/ipie/qmc/options.py
+++ b/ipie/qmc/options.py
@@ -156,7 +156,7 @@ class QMCParams:
     pop_control_freq : int
         Frequency at which population control occurs.
     rng_seed : int
-        The random number seed. If run in parallel the seeds on other cores / 
+        The random number seed. If run in parallel the seeds on other cores /
         threads are determined from this.
     """
 

--- a/ipie/qmc/tests/test_afqmc_multi_det_batch.py
+++ b/ipie/qmc/tests/test_afqmc_multi_det_batch.py
@@ -75,7 +75,7 @@ def test_generic_multi_det_batch():
         afqmc.run(verbose=0, estimator_filename=tmpf.name)
         afqmc.finalise(verbose=0)
         afqmc.estimators.compute_estimators(
-            comm, afqmc.system, afqmc.hamiltonian, afqmc.trial, afqmc.walkers
+            afqmc.system, afqmc.hamiltonian, afqmc.trial, afqmc.walkers
         )
         numer_batch = afqmc.estimators["energy"]["ENumer"]
         denom_batch = afqmc.estimators["energy"]["EDenom"]

--- a/ipie/qmc/tests/test_afqmc_single_det_batch.py
+++ b/ipie/qmc/tests/test_afqmc_single_det_batch.py
@@ -78,7 +78,7 @@ def test_generic_single_det_batch():
         afqmc.run(verbose=False, estimator_filename=tmpf.name)
         afqmc.finalise(verbose=0)
         afqmc.estimators.compute_estimators(
-            comm, afqmc.system, afqmc.hamiltonian, afqmc.trial, afqmc.walkers
+            afqmc.system, afqmc.hamiltonian, afqmc.trial, afqmc.walkers
         )
         numer_batch = afqmc.estimators["energy"]["ENumer"]
         denom_batch = afqmc.estimators["energy"]["EDenom"]
@@ -165,7 +165,7 @@ def test_generic_single_det_batch_density_diff():
         afqmc.run(verbose=False, estimator_filename=tmpf.name)
         afqmc.finalise(verbose=0)
         afqmc.estimators.compute_estimators(
-            comm, afqmc.system, afqmc.hamiltonian, afqmc.trial, afqmc.walkers
+            afqmc.system, afqmc.hamiltonian, afqmc.trial, afqmc.walkers
         )
 
         numer_batch = afqmc.estimators["energy"]["ENumer"]

--- a/ipie/trial_wavefunction/single_det.py
+++ b/ipie/trial_wavefunction/single_det.py
@@ -40,7 +40,7 @@ class SingleDet(TrialWavefunctionBase):
         self._max_num_dets = 1
         imag_norm = numpy.sum(self.psi.imag.ravel() * self.psi.imag.ravel())
         if imag_norm <= 1e-8:
-            #print("# making trial wavefunction MO coefficient real")
+            # print("# making trial wavefunction MO coefficient real")
             self.psi = numpy.array(self.psi.real, dtype=numpy.float64)
 
         self.psi0a = self.psi[:, : self.nalpha]

--- a/ipie/trial_wavefunction/tests/test_noci.py
+++ b/ipie/trial_wavefunction/tests/test_noci.py
@@ -35,5 +35,5 @@ def test_noci():
     trial.calculate_energy(sys, ham)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_noci()

--- a/ipie/trial_wavefunction/tests/test_wavefunction_base.py
+++ b/ipie/trial_wavefunction/tests/test_wavefunction_base.py
@@ -18,5 +18,5 @@ def test_wavefunction_base():
     assert trial.nbasis == num_basis
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_wavefunction_base()

--- a/ipie/utils/misc.py
+++ b/ipie/utils/misc.py
@@ -314,9 +314,9 @@ def get_numpy_blas_info() -> Dict[str, str]:
             lib_dir = numpy.__config__.blas_opt_info["library_dirs"]  # pylint: disable=no-member
         except AttributeError:
             np_lib = numpy.__config__.blas_ilp64_opt_info["libraries"]  # pylint:  disable=no-member
-            lib_dir = numpy.__config__.blas_ilp64_opt_info[
+            lib_dir = numpy.__config__.blas_ilp64_opt_info[  # pylint:  disable=no-member
                 "library_dirs"
-            ]  # pylint:  disable=no-member
+            ]
         print(f"# - BLAS lib: {' '.join(np_lib):s}")
         print(f"# - BLAS dir: {' '.join(lib_dir):s}")
         info["BLAS"] = {

--- a/ipie/utils/misc.py
+++ b/ipie/utils/misc.py
@@ -310,11 +310,13 @@ def get_numpy_blas_info() -> Dict[str, str]:
             print(f"# - BLAS {k}: {v}")
     except TypeError:
         try:
-            np_lib = numpy.__config__.blas_opt_info["libraries"]
-            lib_dir = numpy.__config__.blas_opt_info["library_dirs"]
+            np_lib = numpy.__config__.blas_opt_info["libraries"]  # pylint:  disable=no-member
+            lib_dir = numpy.__config__.blas_opt_info["library_dirs"]  # pylint: disable=no-member
         except AttributeError:
-            np_lib = numpy.__config__.blas_ilp64_opt_info["libraries"]
-            lib_dir = numpy.__config__.blas_ilp64_opt_info["library_dirs"]
+            np_lib = numpy.__config__.blas_ilp64_opt_info["libraries"]  # pylint:  disable=no-member
+            lib_dir = numpy.__config__.blas_ilp64_opt_info[
+                "library_dirs"
+            ]  # pylint:  disable=no-member
         print(f"# - BLAS lib: {' '.join(np_lib):s}")
         print(f"# - BLAS dir: {' '.join(lib_dir):s}")
         info["BLAS"] = {

--- a/ipie/walkers/pop_controller.py
+++ b/ipie/walkers/pop_controller.py
@@ -5,6 +5,7 @@ import numpy
 from ipie.config import MPI
 from ipie.utils.backend import arraylib as xp
 
+
 class PopControllerTimer:
     def __init__(self):
         self.start_time_const = 0.0
@@ -173,13 +174,15 @@ def set_buffer(walkers, iw, buff):
         assert data.size % walkers.nwalkers == 0  # Only walker-specific data is being communicated
         if isinstance(data[iw], xp.ndarray):
             walkers.__dict__[d][iw] = xp.array(
-                buff[s : s + data[iw].size].reshape(data[iw].shape).copy())
+                buff[s : s + data[iw].size].reshape(data[iw].shape).copy()
+            )
             s += data[iw].size
         elif isinstance(data[iw], list):
             for ix, l in enumerate(data[iw]):
                 if isinstance(l, (xp.ndarray)):
                     walkers.__dict__[d][iw][ix] = xp.array(
-                        buff[s : s + l.size].reshape(l.shape).copy())
+                        buff[s : s + l.size].reshape(l.shape).copy()
+                    )
                     s += l.size
                 elif isinstance(l, (int, float, complex)):
                     walkers.__dict__[d][iw][ix] = buff[s]
@@ -315,11 +318,11 @@ def pair_branch(walkers, comm, max_weight, min_weight, timer=PopControllerTimer(
         glob_inf_1 = numpy.empty([comm.size, walkers.nwalkers], dtype=numpy.int64)
         glob_inf_1.fill(1)
         glob_inf_2 = numpy.array(
-            [[r for i in range(walkers.nwalkers)] for r in range(comm.size)],
-            dtype=numpy.int64)
+            [[r for i in range(walkers.nwalkers)] for r in range(comm.size)], dtype=numpy.int64
+        )
         glob_inf_3 = numpy.array(
-            [[r for i in range(walkers.nwalkers)] for r in range(comm.size)],
-            dtype=numpy.int64)
+            [[r for i in range(walkers.nwalkers)] for r in range(comm.size)], dtype=numpy.int64
+        )
 
     timer.add_non_communication()
 
@@ -337,9 +340,15 @@ def pair_branch(walkers, comm, max_weight, min_weight, timer=PopControllerTimer(
         # Rescale weights.
         glob_inf = numpy.zeros((walkers.nwalkers * comm.size, 4), dtype=numpy.float64)
         glob_inf[:, 0] = glob_inf_0.ravel()  # contains walker |w_i|
-        glob_inf[:, 1] = glob_inf_1.ravel()  # all initialized to 1 when it becomes 2 then it will be "branched"
-        glob_inf[:, 2] = glob_inf_2.ravel()  # contain processor+walker indices (initial) (i.e., where walkers live)
-        glob_inf[:, 3] = glob_inf_3.ravel()  # contain processor+walker indices (final) (i.e., where walkers live)
+        glob_inf[:, 1] = (
+            glob_inf_1.ravel()
+        )  # all initialized to 1 when it becomes 2 then it will be "branched"
+        glob_inf[:, 2] = (
+            glob_inf_2.ravel()
+        )  # contain processor+walker indices (initial) (i.e., where walkers live)
+        glob_inf[:, 3] = (
+            glob_inf_3.ravel()
+        )  # contain processor+walker indices (final) (i.e., where walkers live)
         sort = numpy.argsort(glob_inf[:, 0], kind="mergesort")
         isort = numpy.argsort(sort, kind="mergesort")
         glob_inf = glob_inf[sort]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ h5py >= 3.0.0
 numpy >= 1.20.0
 scipy >= 1.3.0
 pytest
-pandas == 1.5.1 # issue with pyblock and pandas > 2
+pandas
 numba
 plum-dispatch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython >= 0.29.0
 h5py >= 3.0.0
-numpy >= 1.20.0, < 1.26.0
-scipy >= 1.3.0, <=1.10.1
+numpy >= 1.20.0
+scipy >= 1.3.0
 pytest
 pandas == 1.5.1 # issue with pyblock and pandas > 2
 numba

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def main() -> None:
         packages=find_packages(exclude=["examples", "docs", "tests", "tools", "setup.py"]),
         license="Apache 2.0",
         description="Python implementations of Imaginary-time Evolution algorithms",
-        python_requires=">=3.7.0,<3.12.0",
+        python_requires=">=3.8.0",
         scripts=[
             "bin/ipie",
             "tools/extract_dice.py",


### PR DESCRIPTION
* Allow python > 3.11
* Allow numpy >= 1.26
* Bump CI python versions (min version is 3.10)
* Fix lint / format errors introduced in #296 

I split the AFQMC driver into a base class and then implementations for FT / ZT afqmc which allows for more customization of the factory methods.