### PR TITLE
fix the bug where population controller does not update the total weight

### DIFF
--- a/ipie/estimators/local_energy_batch.py
+++ b/ipie/estimators/local_energy_batch.py
@@ -61,15 +61,16 @@ def local_energy_batch(system, hamiltonian, walkers, trial):
                 )
             else:
                 return local_energy_single_det_batch_gpu(system, hamiltonian, walkers, trial)
-        elif walkers.rhf:
-            return local_energy_single_det_rhf_batch(system, hamiltonian, walkers, trial)
         else:
             if hamiltonian.chunked:
                 return local_energy_single_det_uhf_batch_chunked(
                     system, hamiltonian, walkers, trial
                 )
             else:
-                return local_energy_single_det_uhf_batch(system, hamiltonian, walkers, trial)
+                if walkers.rhf:
+                    return local_energy_single_det_rhf_batch(system, hamiltonian, walkers, trial)
+                else:
+                    return local_energy_single_det_uhf_batch(system, hamiltonian, walkers, trial)
     else:
         print("# Warning: local_energy_batch is not production level for multi-det trials.")
         return local_energy_multi_det_trial_batch(system, hamiltonian, walkers, trial)

--- a/ipie/estimators/local_energy_sd.py
+++ b/ipie/estimators/local_energy_sd.py
@@ -1016,60 +1016,98 @@ def local_energy_single_det_batch_gpu(system, hamiltonian, walkers, trial, max_m
     nbeta = walkers.Ghalfb.shape[1]
     nbasis = walkers.Ghalfa.shape[-1]
     nchol = hamiltonian.nchol
+    if walkers.rhf:
+        Ghalfa = walkers.Ghalfa.reshape(nwalkers, nalpha * nbasis)
 
-    Ghalfa = walkers.Ghalfa.reshape(nwalkers, nalpha * nbasis)
-    Ghalfb = walkers.Ghalfb.reshape(nwalkers, nbeta * nbasis)
+        e1b = Ghalfa.dot(trial._rH1a.ravel()) * 2.0 + hamiltonian.ecore
 
-    e1b = Ghalfa.dot(trial._rH1a.ravel()) + Ghalfb.dot(trial._rH1b.ravel()) + hamiltonian.ecore
+        if xp.isrealobj(trial._rchola):
+            Xa = trial._rchola.dot(Ghalfa.real.T) + 1.0j * trial._rchola.dot(
+                Ghalfa.imag.T
+            )  # naux x nwalkers
+        else:
+            Xa = trial._rchola.dot(Ghalfa.T)
 
-    if xp.isrealobj(trial._rchola):
-        Xa = trial._rchola.dot(Ghalfa.real.T) + 1.0j * trial._rchola.dot(
-            Ghalfa.imag.T
-        )  # naux x nwalkers
-        Xb = trial._rcholb.dot(Ghalfb.real.T) + 1.0j * trial._rcholb.dot(
-            Ghalfb.imag.T
-        )  # naux x nwalkers
+        ecoul = 4.0 * xp.einsum("xw,xw->w", Xa, Xa, optimize=True)
+
+        max_nocc = max(nalpha, nbeta)
+        mem_needed = 16 * nwalkers * max_nocc * max_nocc * nchol / (1024.0**3.0)
+        num_chunks = max(1, ceil(mem_needed / max_mem))
+        chunk_size = ceil(nchol / num_chunks)
+        nchol_chunks = ceil(nchol / chunk_size)
+
+        # Buffer for large intermediate tensor
+        buff = xp.zeros(shape=(nwalkers * chunk_size * max_nocc * max_nocc), dtype=xp.complex128)
+        nchol_chunk_size = chunk_size
+        nchol_left = nchol
+        exx = xp.zeros(nwalkers, dtype=xp.complex128)
+        Ghalfa = walkers.Ghalfa.reshape((nwalkers * nalpha, nbasis))
+        for i in range(nchol_chunks):
+            nchol_chunk = min(nchol_chunk_size, nchol_left)
+            chol_sls = slice(i * chunk_size, i * chunk_size + nchol_chunk)
+            size = nwalkers * nchol_chunk * nalpha * nalpha
+            # alpha-alpha
+            Txij = buff[:size].reshape((nchol_chunk * nalpha, nwalkers * nalpha))
+            rchol = trial._rchola[chol_sls].reshape((nchol_chunk * nalpha, nbasis))
+            xp.dot(rchol, Ghalfa.T, out=Txij)
+            Txij = Txij.reshape((nchol_chunk, nalpha, nwalkers, nalpha))
+            exchange_reduction(Txij, exx)
+            nchol_left -= chunk_size
+        e2b = 0.5 * (ecoul - 2. * exx)
     else:
-        Xa = trial._rchola.dot(Ghalfa.T)
-        Xb = trial._rcholb.dot(Ghalfb.T)
+        Ghalfa = walkers.Ghalfa.reshape(nwalkers, nalpha * nbasis)
+        Ghalfb = walkers.Ghalfb.reshape(nwalkers, nbeta * nbasis)
 
-    ecoul = xp.einsum("xw,xw->w", Xa, Xa, optimize=True)
-    ecoul += xp.einsum("xw,xw->w", Xb, Xb, optimize=True)
-    ecoul += 2.0 * xp.einsum("xw,xw->w", Xa, Xb, optimize=True)
+        e1b = Ghalfa.dot(trial._rH1a.ravel()) + Ghalfb.dot(trial._rH1b.ravel()) + hamiltonian.ecore
 
-    max_nocc = max(nalpha, nbeta)
-    mem_needed = 16 * nwalkers * max_nocc * max_nocc * nchol / (1024.0**3.0)
-    num_chunks = max(1, ceil(mem_needed / max_mem))
-    chunk_size = ceil(nchol / num_chunks)
-    nchol_chunks = ceil(nchol / chunk_size)
+        if xp.isrealobj(trial._rchola):
+            Xa = trial._rchola.dot(Ghalfa.real.T) + 1.0j * trial._rchola.dot(
+                Ghalfa.imag.T
+            )  # naux x nwalkers
+            Xb = trial._rcholb.dot(Ghalfb.real.T) + 1.0j * trial._rcholb.dot(
+                Ghalfb.imag.T
+            )  # naux x nwalkers
+        else:
+            Xa = trial._rchola.dot(Ghalfa.T)
+            Xb = trial._rcholb.dot(Ghalfb.T)
 
-    # Buffer for large intermediate tensor
-    buff = xp.zeros(shape=(nwalkers * chunk_size * max_nocc * max_nocc), dtype=xp.complex128)
-    nchol_chunk_size = chunk_size
-    nchol_left = nchol
-    exx = xp.zeros(nwalkers, dtype=xp.complex128)
-    Ghalfa = walkers.Ghalfa.reshape((nwalkers * nalpha, nbasis))
-    Ghalfb = walkers.Ghalfb.reshape((nwalkers * nbeta, nbasis))
-    for i in range(nchol_chunks):
-        nchol_chunk = min(nchol_chunk_size, nchol_left)
-        chol_sls = slice(i * chunk_size, i * chunk_size + nchol_chunk)
-        size = nwalkers * nchol_chunk * nalpha * nalpha
-        # alpha-alpha
-        Txij = buff[:size].reshape((nchol_chunk * nalpha, nwalkers * nalpha))
-        rchol = trial._rchola[chol_sls].reshape((nchol_chunk * nalpha, nbasis))
-        xp.dot(rchol, Ghalfa.T, out=Txij)
-        Txij = Txij.reshape((nchol_chunk, nalpha, nwalkers, nalpha))
-        exchange_reduction(Txij, exx)
-        # beta-beta
-        size = nwalkers * nchol_chunk * nbeta * nbeta
-        Txij = buff[:size].reshape((nchol_chunk * nbeta, nwalkers * nbeta))
-        rchol = trial._rcholb[chol_sls].reshape((nchol_chunk * nbeta, nbasis))
-        xp.dot(rchol, Ghalfb.T, out=Txij)
-        Txij = Txij.reshape((nchol_chunk, nbeta, nwalkers, nbeta))
-        exchange_reduction(Txij, exx)
-        nchol_left -= chunk_size
+        ecoul = xp.einsum("xw,xw->w", Xa, Xa, optimize=True)
+        ecoul += xp.einsum("xw,xw->w", Xb, Xb, optimize=True)
+        ecoul += 2.0 * xp.einsum("xw,xw->w", Xa, Xb, optimize=True)
 
-    e2b = 0.5 * (ecoul - exx)
+        max_nocc = max(nalpha, nbeta)
+        mem_needed = 16 * nwalkers * max_nocc * max_nocc * nchol / (1024.0**3.0)
+        num_chunks = max(1, ceil(mem_needed / max_mem))
+        chunk_size = ceil(nchol / num_chunks)
+        nchol_chunks = ceil(nchol / chunk_size)
+
+        # Buffer for large intermediate tensor
+        buff = xp.zeros(shape=(nwalkers * chunk_size * max_nocc * max_nocc), dtype=xp.complex128)
+        nchol_chunk_size = chunk_size
+        nchol_left = nchol
+        exx = xp.zeros(nwalkers, dtype=xp.complex128)
+        Ghalfa = walkers.Ghalfa.reshape((nwalkers * nalpha, nbasis))
+        Ghalfb = walkers.Ghalfb.reshape((nwalkers * nbeta, nbasis))
+        for i in range(nchol_chunks):
+            nchol_chunk = min(nchol_chunk_size, nchol_left)
+            chol_sls = slice(i * chunk_size, i * chunk_size + nchol_chunk)
+            size = nwalkers * nchol_chunk * nalpha * nalpha
+            # alpha-alpha
+            Txij = buff[:size].reshape((nchol_chunk * nalpha, nwalkers * nalpha))
+            rchol = trial._rchola[chol_sls].reshape((nchol_chunk * nalpha, nbasis))
+            xp.dot(rchol, Ghalfa.T, out=Txij)
+            Txij = Txij.reshape((nchol_chunk, nalpha, nwalkers, nalpha))
+            exchange_reduction(Txij, exx)
+            # beta-beta
+            size = nwalkers * nchol_chunk * nbeta * nbeta
+            Txij = buff[:size].reshape((nchol_chunk * nbeta, nwalkers * nbeta))
+            rchol = trial._rcholb[chol_sls].reshape((nchol_chunk * nbeta, nbasis))
+            xp.dot(rchol, Ghalfb.T, out=Txij)
+            Txij = Txij.reshape((nchol_chunk, nbeta, nwalkers, nbeta))
+            exchange_reduction(Txij, exx)
+            nchol_left -= chunk_size
+
+        e2b = 0.5 * (ecoul - exx)
 
     energy = xp.zeros((nwalkers, 3), dtype=numpy.complex128)
     energy[:, 0] = e1b + e2b

--- a/ipie/estimators/local_energy_sd_chunked.py
+++ b/ipie/estimators/local_energy_sd_chunked.py
@@ -21,6 +21,7 @@ import numpy
 from math import ceil
 
 from ipie.estimators.local_energy_sd import (
+    ecoul_kernel_batch_real_rchol_rhf,
     ecoul_kernel_batch_real_rchol_uhf,
     exx_kernel_batch_real_rchol,
 )
@@ -62,79 +63,137 @@ def local_energy_single_det_uhf_batch_chunked(system, hamiltonian, walker_batch,
     nalpha = walker_batch.Ghalfa.shape[1]
     nbeta = walker_batch.Ghalfb.shape[1]
     nbasis = hamiltonian.nbasis
+    if walker_batch.rhf:
+        Ghalfa = walker_batch.Ghalfa.reshape(nwalkers, nalpha * nbasis)
 
-    Ghalfa = walker_batch.Ghalfa.reshape(nwalkers, nalpha * nbasis)
-    Ghalfb = walker_batch.Ghalfb.reshape(nwalkers, nbeta * nbasis)
+        e1b = 2.0 * Ghalfa.dot(trial._rH1a.ravel())
+        e1b += hamiltonian.ecore
 
-    e1b = Ghalfa.dot(trial._rH1a.ravel())
-    e1b += Ghalfb.dot(trial._rH1b.ravel())
-    e1b += hamiltonian.ecore
+        Ghalfa_send = Ghalfa.copy()
+        Ghalfa_recv = xp.zeros_like(Ghalfa)
 
-    Ghalfa_send = Ghalfa.copy()
-    Ghalfb_send = Ghalfb.copy()
+        handler = walker_batch.mpi_handler
+        senders = handler.senders
+        receivers = handler.receivers
 
-    Ghalfa_recv = xp.zeros_like(Ghalfa)
-    Ghalfb_recv = xp.zeros_like(Ghalfb)
+        rchola_chunk = trial._rchola_chunk
 
-    handler = walker_batch.mpi_handler
-    senders = handler.senders
-    receivers = handler.receivers
+        Ghalfa = Ghalfa.reshape(nwalkers, nalpha * nbasis)
+        ecoul_send = ecoul_kernel_batch_real_rchol_rhf(rchola_chunk, Ghalfa)
+        Ghalfa = Ghalfa.reshape(nwalkers, nalpha, nbasis)
+        exx_send = 2.0 * exx_kernel_batch_real_rchol(rchola_chunk, Ghalfa)
 
-    rchola_chunk = trial._rchola_chunk
-    rcholb_chunk = trial._rcholb_chunk
+        exx_recv = exx_send.copy()
+        ecoul_recv = ecoul_send.copy()
 
-    Ghalfa = Ghalfa.reshape(nwalkers, nalpha * nbasis)
-    Ghalfb = Ghalfb.reshape(nwalkers, nbeta * nbasis)
-    ecoul_send = ecoul_kernel_batch_real_rchol_uhf(rchola_chunk, rcholb_chunk, Ghalfa, Ghalfb)
-    Ghalfa = Ghalfa.reshape(nwalkers, nalpha, nbasis)
-    Ghalfb = Ghalfb.reshape(nwalkers, nbeta, nbasis)
-    exx_send = exx_kernel_batch_real_rchol(rchola_chunk, Ghalfa)
-    exx_send += exx_kernel_batch_real_rchol(rcholb_chunk, Ghalfb)
+        for _ in range(handler.ssize - 1):
+            for isend, sender in enumerate(senders):
+                if handler.srank == isend:
+                    handler.scomm.Send(Ghalfa_send, dest=receivers[isend], tag=1)
+                    handler.scomm.Send(ecoul_send, dest=receivers[isend], tag=2)
+                    handler.scomm.Send(exx_send, dest=receivers[isend], tag=3)
+                elif handler.srank == receivers[isend]:
+                    sender = numpy.where(receivers == handler.srank)[0]
+                    handler.scomm.Recv(Ghalfa_recv, source=sender, tag=1)
+                    handler.scomm.Recv(ecoul_recv, source=sender, tag=2)
+                    handler.scomm.Recv(exx_recv, source=sender, tag=3)
+            handler.scomm.barrier()
 
-    exx_recv = exx_send.copy()
-    ecoul_recv = ecoul_send.copy()
+            # prepare sending
+            ecoul_send = ecoul_recv.copy()
+            Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha * nbasis)
+            ecoul_send += ecoul_kernel_batch_real_rchol_uhf(
+                rchola_chunk, Ghalfa_recv
+            )
+            Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha, nbasis)
+            exx_send = exx_recv.copy()
+            exx_send += 2.0 * exx_kernel_batch_real_rchol(rchola_chunk, Ghalfa_recv)
+            Ghalfa_send = Ghalfa_recv.copy()
 
-    for _ in range(handler.ssize - 1):
-        for isend, sender in enumerate(senders):
-            if handler.srank == isend:
-                handler.scomm.Send(Ghalfa_send, dest=receivers[isend], tag=1)
-                handler.scomm.Send(Ghalfb_send, dest=receivers[isend], tag=2)
-                handler.scomm.Send(ecoul_send, dest=receivers[isend], tag=3)
-                handler.scomm.Send(exx_send, dest=receivers[isend], tag=4)
-            elif handler.srank == receivers[isend]:
-                sender = numpy.where(receivers == handler.srank)[0]
-                handler.scomm.Recv(Ghalfa_recv, source=sender, tag=1)
-                handler.scomm.Recv(Ghalfb_recv, source=sender, tag=2)
-                handler.scomm.Recv(ecoul_recv, source=sender, tag=3)
-                handler.scomm.Recv(exx_recv, source=sender, tag=4)
-        handler.scomm.barrier()
+        if len(senders) > 1:
+            for isend, sender in enumerate(senders):
+                if handler.srank == sender:  # sending 1 xshifted to 0 xshifted_buf
+                    handler.scomm.Send(ecoul_send, dest=receivers[isend], tag=1)
+                    handler.scomm.Send(exx_send, dest=receivers[isend], tag=2)
+                elif handler.srank == receivers[isend]:
+                    sender = numpy.where(receivers == handler.srank)[0]
+                    handler.scomm.Recv(ecoul_recv, source=sender, tag=1)
+                    handler.scomm.Recv(exx_recv, source=sender, tag=2)
 
-        # prepare sending
-        ecoul_send = ecoul_recv.copy()
-        Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha * nbasis)
-        Ghalfb_recv = Ghalfb_recv.reshape(nwalkers, nbeta * nbasis)
-        ecoul_send += ecoul_kernel_batch_real_rchol_uhf(
-            rchola_chunk, rcholb_chunk, Ghalfa_recv, Ghalfb_recv
-        )
-        Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha, nbasis)
-        Ghalfb_recv = Ghalfb_recv.reshape(nwalkers, nbeta, nbasis)
-        exx_send = exx_recv.copy()
-        exx_send += exx_kernel_batch_real_rchol(rchola_chunk, Ghalfa_recv)
-        exx_send += exx_kernel_batch_real_rchol(rcholb_chunk, Ghalfb_recv)
-        Ghalfa_send = Ghalfa_recv.copy()
-        Ghalfb_send = Ghalfb_recv.copy()
+        e2b = ecoul_recv - exx_recv
+    else:
+        Ghalfa = walker_batch.Ghalfa.reshape(nwalkers, nalpha * nbasis)
+        Ghalfb = walker_batch.Ghalfb.reshape(nwalkers, nbeta * nbasis)
 
-    if len(senders) > 1:
-        for isend, sender in enumerate(senders):
-            if handler.srank == sender:  # sending 1 xshifted to 0 xshifted_buf
-                handler.scomm.Send(ecoul_send, dest=receivers[isend], tag=1)
-                handler.scomm.Send(exx_send, dest=receivers[isend], tag=2)
-            elif handler.srank == receivers[isend]:
-                sender = numpy.where(receivers == handler.srank)[0]
-                handler.scomm.Recv(ecoul_recv, source=sender, tag=1)
-                handler.scomm.Recv(exx_recv, source=sender, tag=2)
+        e1b = Ghalfa.dot(trial._rH1a.ravel())
+        e1b += Ghalfb.dot(trial._rH1b.ravel())
+        e1b += hamiltonian.ecore
 
-    e2b = ecoul_recv - exx_recv
+        Ghalfa_send = Ghalfa.copy()
+        Ghalfb_send = Ghalfb.copy()
+
+        Ghalfa_recv = xp.zeros_like(Ghalfa)
+        Ghalfb_recv = xp.zeros_like(Ghalfb)
+
+        handler = walker_batch.mpi_handler
+        senders = handler.senders
+        receivers = handler.receivers
+
+        rchola_chunk = trial._rchola_chunk
+        rcholb_chunk = trial._rcholb_chunk
+
+        Ghalfa = Ghalfa.reshape(nwalkers, nalpha * nbasis)
+        Ghalfb = Ghalfb.reshape(nwalkers, nbeta * nbasis)
+        ecoul_send = ecoul_kernel_batch_real_rchol_uhf(rchola_chunk, rcholb_chunk, Ghalfa, Ghalfb)
+        Ghalfa = Ghalfa.reshape(nwalkers, nalpha, nbasis)
+        Ghalfb = Ghalfb.reshape(nwalkers, nbeta, nbasis)
+        exx_send = exx_kernel_batch_real_rchol(rchola_chunk, Ghalfa)
+        exx_send += exx_kernel_batch_real_rchol(rcholb_chunk, Ghalfb)
+
+        exx_recv = exx_send.copy()
+        ecoul_recv = ecoul_send.copy()
+
+        for _ in range(handler.ssize - 1):
+            for isend, sender in enumerate(senders):
+                if handler.srank == isend:
+                    handler.scomm.Send(Ghalfa_send, dest=receivers[isend], tag=1)
+                    handler.scomm.Send(Ghalfb_send, dest=receivers[isend], tag=2)
+                    handler.scomm.Send(ecoul_send, dest=receivers[isend], tag=3)
+                    handler.scomm.Send(exx_send, dest=receivers[isend], tag=4)
+                elif handler.srank == receivers[isend]:
+                    sender = numpy.where(receivers == handler.srank)[0]
+                    handler.scomm.Recv(Ghalfa_recv, source=sender, tag=1)
+                    handler.scomm.Recv(Ghalfb_recv, source=sender, tag=2)
+                    handler.scomm.Recv(ecoul_recv, source=sender, tag=3)
+                    handler.scomm.Recv(exx_recv, source=sender, tag=4)
+            handler.scomm.barrier()
+
+            # prepare sending
+            ecoul_send = ecoul_recv.copy()
+            Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha * nbasis)
+            Ghalfb_recv = Ghalfb_recv.reshape(nwalkers, nbeta * nbasis)
+            ecoul_send += ecoul_kernel_batch_real_rchol_uhf(
+                rchola_chunk, rcholb_chunk, Ghalfa_recv, Ghalfb_recv
+            )
+            Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha, nbasis)
+            Ghalfb_recv = Ghalfb_recv.reshape(nwalkers, nbeta, nbasis)
+            exx_send = exx_recv.copy()
+            exx_send += exx_kernel_batch_real_rchol(rchola_chunk, Ghalfa_recv)
+            exx_send += exx_kernel_batch_real_rchol(rcholb_chunk, Ghalfb_recv)
+            Ghalfa_send = Ghalfa_recv.copy()
+            Ghalfb_send = Ghalfb_recv.copy()
+
+        if len(senders) > 1:
+            for isend, sender in enumerate(senders):
+                if handler.srank == sender:  # sending 1 xshifted to 0 xshifted_buf
+                    handler.scomm.Send(ecoul_send, dest=receivers[isend], tag=1)
+                    handler.scomm.Send(exx_send, dest=receivers[isend], tag=2)
+                elif handler.srank == receivers[isend]:
+                    sender = numpy.where(receivers == handler.srank)[0]
+                    handler.scomm.Recv(ecoul_recv, source=sender, tag=1)
+                    handler.scomm.Recv(exx_recv, source=sender, tag=2)
+
+        e2b = ecoul_recv - exx_recv
 
     energy = xp.zeros((nwalkers, 3), dtype=numpy.complex128)
     energy[:, 0] = e1b + e2b
@@ -182,6 +241,36 @@ def ecoul_kernel_batch_rchol_uhf_gpu(rchola_chunk, rcholb_chunk, Ghalfa, Ghalfb)
 
     return ecoul
 
+def ecoul_kernel_batch_rchol_rhf_gpu(rchola_chunk, Ghalfa):
+    """Compute coulomb contribution for rchol with RHF trial.
+
+    Parameters
+    ----------
+    rchola_chunk : :class:`numpy.ndarray`
+        Half-rotated cholesky (alpha).
+    rcholb_chunk : :class:`numpy.ndarray`
+        Half-rotated cholesky (beta).
+    Ghalfa : :class:`numpy.ndarray`
+        Walker's half-rotated "green's function" shape is nalpha  x nbasis.
+    Ghalfb : :class:`numpy.ndarray`
+        Walker's half-rotated "green's function" shape is nbeta x nbasis.
+
+    Returns
+    -------
+    ecoul : :class:`numpy.ndarray`
+        coulomb contribution for all walkers.
+    """
+    if xp.isrealobj(rchola_chunk):
+        Xa = rchola_chunk.dot(Ghalfa.real.T) + 1.0j * rchola_chunk.dot(
+            Ghalfa.imag.T
+        )  # naux x nwalkers
+    else:
+        Xa = rchola_chunk.dot(Ghalfa.T)
+
+    ecoul = 4.0 * xp.einsum("xw,xw->w", Xa, Xa, optimize=True)
+    ecoul *= 0.5
+
+    return ecoul
 
 def exx_kernel_batch_rchol_gpu(rchola_chunk, Ghalfa):
     """Compute exchange contribution for complex rchol.
@@ -265,89 +354,158 @@ def local_energy_single_det_uhf_batch_chunked_gpu(
     nbeta = walker_batch.Ghalfb.shape[1]
     nbasis = hamiltonian.nbasis
 
-    Ghalfa = walker_batch.Ghalfa.reshape(nwalkers, nalpha * nbasis)
-    Ghalfb = walker_batch.Ghalfb.reshape(nwalkers, nbeta * nbasis)
+    if walker_batch.rhf:
+        Ghalfa = walker_batch.Ghalfa.reshape(nwalkers, nalpha * nbasis)
 
-    e1b = Ghalfa.dot(trial._rH1a.ravel())
-    e1b += Ghalfb.dot(trial._rH1b.ravel())
-    e1b += hamiltonian.ecore
+        e1b = 2.0 * Ghalfa.dot(trial._rH1a.ravel())
+        e1b += hamiltonian.ecore
 
-    Ghalfa_send = Ghalfa.copy()
-    Ghalfb_send = Ghalfb.copy()
+        Ghalfa_send = Ghalfa.copy()
 
-    Ghalfa_recv = xp.zeros_like(Ghalfa)
-    Ghalfb_recv = xp.zeros_like(Ghalfb)
+        Ghalfa_recv = xp.zeros_like(Ghalfa)
 
-    handler = walker_batch.mpi_handler
-    receivers = handler.receivers
+        handler = walker_batch.mpi_handler
+        receivers = handler.receivers
 
-    rchola_chunk = trial._rchola_chunk
-    rcholb_chunk = trial._rcholb_chunk
+        rchola_chunk = trial._rchola_chunk
 
-    # buffer for low on GPU memory usage
-    max_nchol = max(trial._rchola_chunk.shape[0], trial._rcholb_chunk.shape[0])
-    max_nocc = max(nalpha, nbeta)
-    mem_needed = 16 * nwalkers * max_nocc * max_nocc * max_nchol / (1024.0**3.0)
-    num_chunks = max(1, ceil(mem_needed / max_mem))
-    chunk_size = ceil(max_nchol / num_chunks)
-    buff = xp.zeros(shape=(chunk_size, nwalkers * max_nocc * max_nocc), dtype=numpy.complex128)
+        # buffer for low on GPU memory usage
+        max_nchol = max(trial._rchola_chunk.shape[0], trial._rcholb_chunk.shape[0])
+        max_nocc = max(nalpha, nbeta)
+        mem_needed = 16 * nwalkers * max_nocc * max_nocc * max_nchol / (1024.0**3.0)
+        num_chunks = max(1, ceil(mem_needed / max_mem))
+        chunk_size = ceil(max_nchol / num_chunks)
+        buff = xp.zeros(shape=(chunk_size, nwalkers * max_nocc * max_nocc), dtype=numpy.complex128)
 
-    Ghalfa = Ghalfa.reshape(nwalkers, nalpha * nbasis)
-    Ghalfb = Ghalfb.reshape(nwalkers, nbeta * nbasis)
-    ecoul_send = ecoul_kernel_batch_rchol_uhf_gpu(rchola_chunk, rcholb_chunk, Ghalfa, Ghalfb)
-    Ghalfa = Ghalfa.reshape(nwalkers, nalpha, nbasis)
-    Ghalfb = Ghalfb.reshape(nwalkers, nbeta, nbasis)
-    exx_send = exx_kernel_batch_rchol_gpu_low_mem(rchola_chunk, Ghalfa, buff)
-    exx_send += exx_kernel_batch_rchol_gpu_low_mem(rcholb_chunk, Ghalfb, buff)
+        Ghalfa = Ghalfa.reshape(nwalkers, nalpha * nbasis)
+        ecoul_send = ecoul_kernel_batch_rchol_rhf_gpu(rchola_chunk, Ghalfa)
+        Ghalfa = Ghalfa.reshape(nwalkers, nalpha, nbasis)
+        exx_send = 2.0 * exx_kernel_batch_rchol_gpu_low_mem(rchola_chunk, Ghalfa, buff)
 
-    exx_recv = exx_send.copy()
-    ecoul_recv = ecoul_send.copy()
+        exx_recv = exx_send.copy()
+        ecoul_recv = ecoul_send.copy()
 
-    srank = handler.srank
+        srank = handler.srank
 
-    sender = numpy.where(receivers == handler.srank)[0]
-    scomm = handler.scomm
-    for _ in range(handler.ssize - 1):
+        sender = numpy.where(receivers == handler.srank)[0]
+        scomm = handler.scomm
+        for _ in range(handler.ssize - 1):
+            synchronize()
+            scomm.Isend(Ghalfa_send, dest=receivers[srank], tag=1)
+            scomm.Isend(ecoul_send, dest=receivers[srank], tag=2)
+            scomm.Isend(exx_send, dest=receivers[srank], tag=3)
+            req1 = scomm.Irecv(Ghalfa_recv, source=sender, tag=1)
+            req2 = scomm.Irecv(ecoul_recv, source=sender, tag=2)
+            req3 = scomm.Irecv(exx_recv, source=sender, tag=3)
+            req1.wait()
+            req2.wait()
+            req3.wait()
+            scomm.barrier()
+
+            # prepare sending
+            ecoul_send = ecoul_recv.copy()
+            Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha * nbasis)
+            ecoul_send += ecoul_kernel_batch_rchol_rhf_gpu(rchola_chunk, Ghalfa_recv)
+            Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha, nbasis)
+            exx_send = exx_recv.copy()
+            exx_send += 2.0 * exx_kernel_batch_rchol_gpu_low_mem(rchola_chunk, Ghalfa_recv, buff)
+            Ghalfa_send = Ghalfa_recv.copy()
+
         synchronize()
-        scomm.Isend(Ghalfa_send, dest=receivers[srank], tag=1)
-        scomm.Isend(Ghalfb_send, dest=receivers[srank], tag=2)
-        scomm.Isend(ecoul_send, dest=receivers[srank], tag=3)
-        scomm.Isend(exx_send, dest=receivers[srank], tag=4)
-        req1 = scomm.Irecv(Ghalfa_recv, source=sender, tag=1)
-        req2 = scomm.Irecv(Ghalfb_recv, source=sender, tag=2)
-        req3 = scomm.Irecv(ecoul_recv, source=sender, tag=3)
-        req4 = scomm.Irecv(exx_recv, source=sender, tag=4)
+        scomm.Isend(ecoul_send, dest=receivers[srank], tag=1)
+        scomm.Isend(exx_send, dest=receivers[srank], tag=2)
+        req1 = scomm.Irecv(ecoul_recv, source=sender, tag=1)
+        req2 = scomm.Irecv(exx_recv, source=sender, tag=2)
         req1.wait()
         req2.wait()
-        req3.wait()
-        req4.wait()
-        scomm.barrier()
+        handler.scomm.barrier()
 
-        # prepare sending
-        ecoul_send = ecoul_recv.copy()
-        Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha * nbasis)
-        Ghalfb_recv = Ghalfb_recv.reshape(nwalkers, nbeta * nbasis)
-        ecoul_send += ecoul_kernel_batch_rchol_uhf_gpu(
-            rchola_chunk, rcholb_chunk, Ghalfa_recv, Ghalfb_recv
-        )
-        Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha, nbasis)
-        Ghalfb_recv = Ghalfb_recv.reshape(nwalkers, nbeta, nbasis)
-        exx_send = exx_recv.copy()
-        exx_send += exx_kernel_batch_rchol_gpu_low_mem(rchola_chunk, Ghalfa_recv, buff)
-        exx_send += exx_kernel_batch_rchol_gpu_low_mem(rcholb_chunk, Ghalfb_recv, buff)
-        Ghalfa_send = Ghalfa_recv.copy()
-        Ghalfb_send = Ghalfb_recv.copy()
+        e2b = ecoul_recv - exx_recv
 
-    synchronize()
-    scomm.Isend(ecoul_send, dest=receivers[srank], tag=1)
-    scomm.Isend(exx_send, dest=receivers[srank], tag=2)
-    req1 = scomm.Irecv(ecoul_recv, source=sender, tag=1)
-    req2 = scomm.Irecv(exx_recv, source=sender, tag=2)
-    req1.wait()
-    req2.wait()
-    handler.scomm.barrier()
+    else:
+        Ghalfa = walker_batch.Ghalfa.reshape(nwalkers, nalpha * nbasis)
+        Ghalfb = walker_batch.Ghalfb.reshape(nwalkers, nbeta * nbasis)
 
-    e2b = ecoul_recv - exx_recv
+        e1b = Ghalfa.dot(trial._rH1a.ravel())
+        e1b += Ghalfb.dot(trial._rH1b.ravel())
+        e1b += hamiltonian.ecore
+
+        Ghalfa_send = Ghalfa.copy()
+        Ghalfb_send = Ghalfb.copy()
+
+        Ghalfa_recv = xp.zeros_like(Ghalfa)
+        Ghalfb_recv = xp.zeros_like(Ghalfb)
+
+        handler = walker_batch.mpi_handler
+        receivers = handler.receivers
+
+        rchola_chunk = trial._rchola_chunk
+        rcholb_chunk = trial._rcholb_chunk
+
+        # buffer for low on GPU memory usage
+        max_nchol = max(trial._rchola_chunk.shape[0], trial._rcholb_chunk.shape[0])
+        max_nocc = max(nalpha, nbeta)
+        mem_needed = 16 * nwalkers * max_nocc * max_nocc * max_nchol / (1024.0**3.0)
+        num_chunks = max(1, ceil(mem_needed / max_mem))
+        chunk_size = ceil(max_nchol / num_chunks)
+        buff = xp.zeros(shape=(chunk_size, nwalkers * max_nocc * max_nocc), dtype=numpy.complex128)
+
+        Ghalfa = Ghalfa.reshape(nwalkers, nalpha * nbasis)
+        Ghalfb = Ghalfb.reshape(nwalkers, nbeta * nbasis)
+        ecoul_send = ecoul_kernel_batch_rchol_uhf_gpu(rchola_chunk, rcholb_chunk, Ghalfa, Ghalfb)
+        Ghalfa = Ghalfa.reshape(nwalkers, nalpha, nbasis)
+        Ghalfb = Ghalfb.reshape(nwalkers, nbeta, nbasis)
+        exx_send = exx_kernel_batch_rchol_gpu_low_mem(rchola_chunk, Ghalfa, buff)
+        exx_send += exx_kernel_batch_rchol_gpu_low_mem(rcholb_chunk, Ghalfb, buff)
+
+        exx_recv = exx_send.copy()
+        ecoul_recv = ecoul_send.copy()
+
+        srank = handler.srank
+
+        sender = numpy.where(receivers == handler.srank)[0]
+        scomm = handler.scomm
+        for _ in range(handler.ssize - 1):
+            synchronize()
+            scomm.Isend(Ghalfa_send, dest=receivers[srank], tag=1)
+            scomm.Isend(Ghalfb_send, dest=receivers[srank], tag=2)
+            scomm.Isend(ecoul_send, dest=receivers[srank], tag=3)
+            scomm.Isend(exx_send, dest=receivers[srank], tag=4)
+            req1 = scomm.Irecv(Ghalfa_recv, source=sender, tag=1)
+            req2 = scomm.Irecv(Ghalfb_recv, source=sender, tag=2)
+            req3 = scomm.Irecv(ecoul_recv, source=sender, tag=3)
+            req4 = scomm.Irecv(exx_recv, source=sender, tag=4)
+            req1.wait()
+            req2.wait()
+            req3.wait()
+            req4.wait()
+            scomm.barrier()
+
+            # prepare sending
+            ecoul_send = ecoul_recv.copy()
+            Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha * nbasis)
+            Ghalfb_recv = Ghalfb_recv.reshape(nwalkers, nbeta * nbasis)
+            ecoul_send += ecoul_kernel_batch_rchol_uhf_gpu(
+                rchola_chunk, rcholb_chunk, Ghalfa_recv, Ghalfb_recv
+            )
+            Ghalfa_recv = Ghalfa_recv.reshape(nwalkers, nalpha, nbasis)
+            Ghalfb_recv = Ghalfb_recv.reshape(nwalkers, nbeta, nbasis)
+            exx_send = exx_recv.copy()
+            exx_send += exx_kernel_batch_rchol_gpu_low_mem(rchola_chunk, Ghalfa_recv, buff)
+            exx_send += exx_kernel_batch_rchol_gpu_low_mem(rcholb_chunk, Ghalfb_recv, buff)
+            Ghalfa_send = Ghalfa_recv.copy()
+            Ghalfb_send = Ghalfb_recv.copy()
+
+        synchronize()
+        scomm.Isend(ecoul_send, dest=receivers[srank], tag=1)
+        scomm.Isend(exx_send, dest=receivers[srank], tag=2)
+        req1 = scomm.Irecv(ecoul_recv, source=sender, tag=1)
+        req2 = scomm.Irecv(exx_recv, source=sender, tag=2)
+        req1.wait()
+        req2.wait()
+        handler.scomm.barrier()
+
+        e2b = ecoul_recv - exx_recv
 
     energy = xp.zeros((nwalkers, 3), dtype=numpy.complex128)
     energy[:, 0] = e1b + e2b

--- a/ipie/walkers/pop_controller.py
+++ b/ipie/walkers/pop_controller.py
@@ -109,6 +109,7 @@ class PopController:
         # Todo: Just standardise information we want to send between routines.
         walkers.unscaled_weight = walkers.weight
         walkers.weight = walkers.weight / scale
+        self.total_weight = self.target_weight
         if self.method == "comb":
             global_weights = global_weights / scale
             self.timer.add_non_communication()


### PR DESCRIPTION
The original code does not update the total weight in the population controller which causes the total weight to decay exponentially. As a result, after several steps, the total weight of the walkers will be small so that at each step the weights will be capped by the weight bound which is 0.1x the total weight, then the rescaling in the population controller does not have any effect since it will immediately get capped in the next step.
The fix is updating the total weight stored in the population controller as we rescale the weights of the walkers.